### PR TITLE
Unify mobile auth AsyncStorage keys and fix login/refresh/logout flows

### DIFF
--- a/mobile/screens/LoginScreen.js
+++ b/mobile/screens/LoginScreen.js
@@ -14,6 +14,7 @@ import {
 import { LinearGradient } from "expo-linear-gradient";
 import { MaterialCommunityIcons } from "@expo/vector-icons";
 import AsyncStorage from "@react-native-async-storage/async-storage";
+import { TOKEN_KEY, REFRESH_KEY, USERNAME_KEY } from "../services/authKeys";
 import axios from "axios";
 import { API_BASE_URL } from "../config";
 
@@ -39,8 +40,11 @@ export default function LoginScreen({ onLoginSuccess, onSwitchToRegister }) {
       });
 
       if (response.data.access_token) {
-        await AsyncStorage.setItem("sb_token", response.data.access_token);
-        await AsyncStorage.setItem("sb_username", username);
+        await AsyncStorage.setItem(TOKEN_KEY, response.data.access_token);
+        if (response.data.refresh_token) {
+          await AsyncStorage.setItem(REFRESH_KEY, response.data.refresh_token);
+        }
+        await AsyncStorage.setItem(USERNAME_KEY, username);
         onLoginSuccess();
       } else {
         Alert.alert("Login Failed", "Invalid credentials");

--- a/mobile/screens/SettingsScreen.js
+++ b/mobile/screens/SettingsScreen.js
@@ -4,6 +4,7 @@ import { MaterialCommunityIcons } from "@expo/vector-icons";
 import { LinearGradient } from "expo-linear-gradient";
 
 import AsyncStorage from "@react-native-async-storage/async-storage";
+import { TOKEN_KEY, REFRESH_KEY, USERNAME_KEY } from "../services/authKeys";
 
 const { width } = Dimensions.get("window");
 
@@ -13,8 +14,9 @@ export default function SettingsScreen({ onLogout }) {
 
   const handleLogout = async () => {
     try {
-      await AsyncStorage.removeItem("sb_token");
-      await AsyncStorage.removeItem("sb_username");
+      await AsyncStorage.removeItem(TOKEN_KEY);
+      await AsyncStorage.removeItem(REFRESH_KEY);
+      await AsyncStorage.removeItem(USERNAME_KEY);
       if (onLogout) onLogout();
     } catch (e) {
       console.error(e);

--- a/mobile/services/api.js
+++ b/mobile/services/api.js
@@ -1,4 +1,5 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
+import { TOKEN_KEY, REFRESH_KEY, USERNAME_KEY } from "./authKeys";
 import { API_BASE_URL } from "../config";
 import axios from "axios";
 
@@ -68,8 +69,8 @@ api.interceptors.response.use(
       isRefreshing = true;
 
       try {
-        // Attempt to refresh token
-        const refreshToken = await AsyncStorage.getItem("sb_refresh_token");
+          // Attempt to refresh token
+          const refreshToken = await AsyncStorage.getItem(REFRESH_KEY);
         if (!refreshToken) {
           throw new Error("No refresh token available");
         }
@@ -81,9 +82,8 @@ api.interceptors.response.use(
         const { access_token, refresh_token: new_refresh_token } = response.data;
 
         // Store new tokens
-        await AsyncStorage.setItem("verath_token", access_token);
-        await AsyncStorage.setItem("verath_refresh_token", new_refresh_token);
-        await AsyncStorage.removeItem("verath_username");
+        await AsyncStorage.setItem(TOKEN_KEY, access_token);
+        await AsyncStorage.setItem(REFRESH_KEY, new_refresh_token);
         onRefreshed(access_token);
 
         // Retry original request with new token
@@ -110,7 +110,7 @@ api.interceptors.response.use(
 );
 
 const getAuthHeader = async () => {
-  const token = await AsyncStorage.getItem("verath_token");
+  const token = await AsyncStorage.getItem(TOKEN_KEY);
   return token ? { 'Authorization': `Bearer ${token}` } : {};
 };
 
@@ -349,8 +349,9 @@ export const login = async (username, password) => {
     }
     
     const data = await response.json();
-    await AsyncStorage.setItem('verath_token', data.access_token);
-    await AsyncStorage.setItem('verath_username', data.username);
+    await AsyncStorage.setItem(TOKEN_KEY, data.access_token);
+    if (data.refresh_token) await AsyncStorage.setItem(REFRESH_KEY, data.refresh_token);
+    if (data.username) await AsyncStorage.setItem(USERNAME_KEY, data.username);
     return data;
   } catch (error) {
     console.error('Error logging in:', error);
@@ -380,8 +381,9 @@ export const signup = async (username, password) => {
 
 export const logout = async () => {
   try {
-    await AsyncStorage.removeItem('verath_token');
-    await AsyncStorage.removeItem('verath_username');
+    await AsyncStorage.removeItem(TOKEN_KEY);
+    await AsyncStorage.removeItem(REFRESH_KEY);
+    await AsyncStorage.removeItem(USERNAME_KEY);
     return true;
   } catch (error) {
     console.error('Error logging out:', error);

--- a/mobile/services/auth.js
+++ b/mobile/services/auth.js
@@ -1,5 +1,6 @@
 import React, { useState, createContext, useEffect } from 'react';
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import { TOKEN_KEY, REFRESH_KEY, USERNAME_KEY } from './authKeys';
 import axios from 'axios';
 import { API_BASE_URL } from "../config";
 
@@ -15,7 +16,9 @@ export const AuthProvider = ({ children }) => {
     try {
       const response = await axios.post(`${API_BASE}/auth/login`, { username, password });
       const token = response.data.access_token;
-      await AsyncStorage.setItem('userToken', token);
+      await AsyncStorage.setItem(TOKEN_KEY, token);
+      if (response.data.refresh_token) await AsyncStorage.setItem(REFRESH_KEY, response.data.refresh_token);
+      if (response.data.username) await AsyncStorage.setItem(USERNAME_KEY, response.data.username);
       setUserToken(token);
     } catch (e) {
       console.error("Login failed", e);
@@ -24,14 +27,16 @@ export const AuthProvider = ({ children }) => {
   };
 
   const logout = async () => {
-    await AsyncStorage.removeItem('userToken');
+    await AsyncStorage.removeItem(TOKEN_KEY);
+    await AsyncStorage.removeItem(REFRESH_KEY);
+    await AsyncStorage.removeItem(USERNAME_KEY);
     setUserToken(null);
   };
 
   const isLoggedIn = async () => {
     try {
       setIsLoading(true);
-      let token = await AsyncStorage.getItem('userToken');
+      let token = await AsyncStorage.getItem(TOKEN_KEY);
       setUserToken(token);
       setIsLoading(false);
     } catch (e) {

--- a/mobile/services/authKeys.js
+++ b/mobile/services/authKeys.js
@@ -1,0 +1,11 @@
+// Centralized AsyncStorage keys for authentication
+export const TOKEN_KEY = 'verath_token';
+export const REFRESH_KEY = 'verath_refresh_token';
+export const USERNAME_KEY = 'verath_username';
+
+// Helper export for convenience
+export default {
+  TOKEN_KEY,
+  REFRESH_KEY,
+  USERNAME_KEY,
+};


### PR DESCRIPTION
**Title**: Unify mobile auth AsyncStorage keys and fix login/refresh/logout flows

**Summary**:  
- Resolve inconsistent AsyncStorage key usage across the mobile app by introducing a single canonical key set and updating all auth flows to use it. Fixes cases where a successful login still left the app in a logged-out state and where refresh/logout could fail due to mismatched keys.

**What changed**:  
- **Added**: authKeys.js — canonical keys (`verath_token`, `verath_refresh_token`, `verath_username`).  
- **Updated**: LoginScreen.js — store canonical keys on login.  
- **Updated**: api.js — request/refresh/login/logout now use canonical keys; refresh uses `verath_refresh_token` and preserves username.  
- **Updated**: auth.js — AuthProvider persists/clears canonical keys.  
- **Updated**: SettingsScreen.js — logout clears canonical keys.

Files changed:  
- authKeys.js  
- LoginScreen.js  
- api.js  
- auth.js  
- SettingsScreen.js

**Verification steps**:  
1. Start the app.  
2. Log in with valid credentials — confirm AsyncStorage contains `verath_token` (and `verath_refresh_token` if returned) and `verath_username`.  
3. Restart the app — it should detect `verath_token` and remain signed in.  
4. Trigger a 401 from the API (or wait for token expiry) — confirm refresh uses `verath_refresh_token`, replaces tokens, and retries the original request.  
5. Logout from settings — confirm `verath_token`, `verath_refresh_token`, and `verath_username` are cleared and app returns to the login screen.