### PR TITLE
Fix privacy toggle scoping

### DIFF
--- a/backend/app/routes/privacy.py
+++ b/backend/app/routes/privacy.py
@@ -1,15 +1,16 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 
+from app.services.auth import get_current_user_id
 from app.services.privacy import is_private, toggle_privacy
 
-router = APIRouter()
+router = APIRouter(prefix="/privacy", tags=["privacy"])
 
 
 @router.get("/")
-def get_privacy():
-    return {"private": is_private()}
+def get_privacy(user_id: str = Depends(get_current_user_id)):
+    return {"private": is_private(user_id)}
 
 
 @router.post("/toggle")
-def toggle():
-    return {"private": toggle_privacy()}
+def toggle(user_id: str = Depends(get_current_user_id)):
+    return {"private": toggle_privacy(user_id)}

--- a/backend/app/services/pipeline.py
+++ b/backend/app/services/pipeline.py
@@ -18,7 +18,7 @@ async def process_audio(file_path: str, user_id: str, timestamp: Optional[str] =
     """Process audio file through the complete pipeline with intelligent extraction."""
     try:
         # Check privacy mode
-        if is_private():
+        if is_private(user_id):
             logger.info("Privacy mode enabled - skipping processing")
             return None
         

--- a/backend/app/services/privacy.py
+++ b/backend/app/services/privacy.py
@@ -1,11 +1,12 @@
-PRIVATE_MODE = False
+_PRIVATE_MODES: dict[str, bool] = {}
 
 
-def toggle_privacy():
-    global PRIVATE_MODE
-    PRIVATE_MODE = not PRIVATE_MODE
-    return PRIVATE_MODE
+def toggle_privacy(user_id: str):
+    current_state = _PRIVATE_MODES.get(user_id, False)
+    new_state = not current_state
+    _PRIVATE_MODES[user_id] = new_state
+    return new_state
 
 
-def is_private():
-    return PRIVATE_MODE
+def is_private(user_id: str):
+    return _PRIVATE_MODES.get(user_id, False)

--- a/backend/tests/test_privacy.py
+++ b/backend/tests/test_privacy.py
@@ -7,10 +7,10 @@ class TestPrivacy:
 
     async def test_privacy_endpoints_require_authentication(self, client):
         response = await client.get("/privacy/")
-        assert response.status_code == 401
+        assert response.status_code == 403
 
         response = await client.post("/privacy/toggle")
-        assert response.status_code == 401
+        assert response.status_code == 403
 
     async def test_privacy_toggle_is_scoped_to_each_user(self, client, auth_headers):
         other_headers = {"Authorization": f"Bearer {create_access_token('other_user')}"}

--- a/backend/tests/test_privacy.py
+++ b/backend/tests/test_privacy.py
@@ -1,0 +1,37 @@
+from app.services.auth import create_access_token
+from app.services.privacy import is_private, toggle_privacy
+
+
+class TestPrivacy:
+    """Test privacy controls."""
+
+    async def test_privacy_endpoints_require_authentication(self, client):
+        response = await client.get("/privacy/")
+        assert response.status_code == 401
+
+        response = await client.post("/privacy/toggle")
+        assert response.status_code == 401
+
+    async def test_privacy_toggle_is_scoped_to_each_user(self, client, auth_headers):
+        other_headers = {"Authorization": f"Bearer {create_access_token('other_user')}"}
+
+        response = await client.post("/privacy/toggle", headers=auth_headers)
+        assert response.status_code == 200
+        assert response.json()["private"] is True
+
+        response = await client.get("/privacy/", headers=auth_headers)
+        assert response.status_code == 200
+        assert response.json()["private"] is True
+
+        response = await client.get("/privacy/", headers=other_headers)
+        assert response.status_code == 200
+        assert response.json()["private"] is False
+
+    async def test_toggle_privacy_helper_flips_state(self):
+        user_id = "helper_user"
+        first_state = toggle_privacy(user_id)
+        second_state = toggle_privacy(user_id)
+
+        assert first_state is True
+        assert second_state is False
+        assert is_private(user_id) is False


### PR DESCRIPTION
## Summary
- Require authenticated access for privacy endpoints
- Scope privacy state per user instead of using a shared process-wide flag
- Update the audio pipeline to respect the authenticated user’s privacy state
- Add tests covering unauthorized access and user isolation

## Root cause
The privacy toggle was public and controlled a global in-memory flag, so any client could disable processing for all users.

## Changes
- Added JWT-based auth dependency to GET /privacy and POST /privacy/toggle
- Replaced global privacy state with per-user state
- Updated process_audio to check privacy for the current user
- Added endpoint and helper tests

## Validation
- Python syntax checks passed for all edited files
- Full pytest run could not be executed locally because required dependencies are not installed in this environment

##Closes : #30 