### PR TITLE
fixed black listed token validity

### DIFF
--- a/backend/app/routes/query.py
+++ b/backend/app/routes/query.py
@@ -2,7 +2,7 @@ import logging
 from fastapi import APIRouter, Depends, HTTPException, Query
 from app.services.query_engine import run_query
 from app.models.schema import QueryResponse
-from app.services.auth import verify_access_token, get_current_user_id
+from app.services.auth import get_current_user_id
 from app.core.logging_config import logger
 
 router = APIRouter()

--- a/backend/app/routes/reminders.py
+++ b/backend/app/routes/reminders.py
@@ -20,7 +20,7 @@ _bearer = HTTPBearer()
 async def _get_current_user(
     creds: HTTPAuthorizationCredentials = Depends(_bearer),
 ) -> str:
-    username = verify_access_token(creds.credentials)
+    username = await verify_access_token(creds.credentials)
     if not username:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,

--- a/backend/app/routes/websocket.py
+++ b/backend/app/routes/websocket.py
@@ -51,7 +51,7 @@ async def websocket_endpoint(websocket: WebSocket, token: str):
     # Verify token and get user_id
     try:
         from app.services.auth import verify_access_token
-        user_id = verify_access_token(token)
+        user_id = await verify_access_token(token)
         if not user_id:
             await websocket.close(code=4001, reason="Invalid token")
             return

--- a/backend/app/services/auth.py
+++ b/backend/app/services/auth.py
@@ -10,6 +10,7 @@ from jose import JWTError, jwt
 from motor.motor_asyncio import AsyncIOMotorClient
 
 from app.config import settings
+from app.services.database import get_db
 
 logger = logging.getLogger(__name__)
 
@@ -49,12 +50,19 @@ def create_refresh_token(username: str) -> str:
 
 
 # ── Token verification ────────────────────────────────────────────────────────
-def verify_access_token(token: str) -> Optional[str]:
+async def verify_access_token(token: str) -> Optional[str]:
     """Returns username if valid access token, else None."""
     try:
         payload = jwt.decode(token, settings.secret_key, algorithms=[ALGORITHM])
         if payload.get("type") != "access":
             return None
+        jti = payload.get("jti")
+        if jti:
+            db = get_db()
+            if db is not None:
+                blacklisted = await db["blacklisted_tokens"].find_one({"jti": jti})
+                if blacklisted:
+                    return None
         return payload.get("sub")
     except JWTError:
         return None
@@ -119,7 +127,7 @@ async def get_current_user_id(
     creds: HTTPAuthorizationCredentials = Depends(_bearer),
 ) -> str:
     """Extract and verify user ID from Bearer token."""
-    username = verify_access_token(creds.credentials)
+    username = await verify_access_token(creds.credentials)
     if not username:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -2,6 +2,7 @@ import pytest
 from httpx import AsyncClient
 from unittest.mock import patch, AsyncMock
 from fastapi import status
+from app.services.auth import create_access_token, verify_access_token
 
 
 class TestAuth:
@@ -113,3 +114,16 @@ class TestAuth:
             json={"username": "user6", "password": "password123"}
         )
         # With proper limiter mock, this would return 429
+
+    async def test_verify_access_token_rejects_blacklisted_jti(self, monkeypatch):
+        """Test that access tokens are rejected once their JTI is blacklisted."""
+        token = create_access_token("testuser")
+        mock_blacklist = AsyncMock(return_value={"jti": "blocked"})
+        mock_db = {"blacklisted_tokens": type("BlacklistCollection", (), {"find_one": mock_blacklist})()}
+
+        monkeypatch.setattr("app.services.auth.get_db", lambda: mock_db)
+
+        username = await verify_access_token(token)
+
+        assert username is None
+        mock_blacklist.assert_awaited_once()


### PR DESCRIPTION
this PR points to issue #51 . Logout now actually revokes the current access token instead of just recording it. We updated token verification to check the blacklist on every authenticated request, so once a user logs out, that token is denied immediately rather than continuing to work until its 7-day expiry. The async auth call sites were updated as part of that change, and a regression test was added to make sure blacklisted tokens return 401 Unauthorized.