### PR TITLE
fix: prevent pending requests from hanging on refresh failure

### DIFF
--- a/mobile/services/api.js
+++ b/mobile/services/api.js
@@ -17,11 +17,16 @@ function subscribeTokenRefresh(callback) {
   refreshSubscribers.push(callback);
 }
 
+function rejectTokenRefresh(error) {
+  refreshSubscribers.forEach((callback) => callback(null, error));
+  refreshSubscribers = [];
+}
+
 /**
  * Execute all pending callbacks with new token
  */
 function onRefreshed(token) {
-  refreshSubscribers.forEach(callback => callback(token));
+  refreshSubscribers.forEach(callback => callback(token, null));
   refreshSubscribers = [];
 }
 
@@ -56,12 +61,13 @@ api.interceptors.response.use(
       if (isRefreshing) {
         // If already refreshing, wait for the refresh to complete
         return new Promise((resolve, reject) => {
-          subscribeTokenRefresh((token) => {
+          subscribeTokenRefresh((token, err) => {
+            if (err) {
+              return reject(err);
+            }
             originalRequest.headers.Authorization = `Bearer ${token}`;
             resolve(api(originalRequest));
           });
-        }).catch((err) => {
-          return Promise.reject(err);
         });
       }
 
@@ -94,6 +100,8 @@ api.interceptors.response.use(
         await AsyncStorage.removeItem("verath_token");
         await AsyncStorage.removeItem("verath_refresh_token");
         await AsyncStorage.removeItem("verath_username");
+        
+        rejectTokenRefresh(refreshError);
         
         // Note: Navigation would need to be handled by the React Native navigation system
         // This is a placeholder - actual implementation would use navigation.navigate('Login')


### PR DESCRIPTION
# Fix mobile token refresh queue edge case

Closes #61

## Summary
Fixes an edge case in the mobile token refresh queue flow where pending requests could remain unresolved if the token refresh failed.

## Changes
- Added failure handling for refresh subscribers.
- Configured the system to reject queued requests when a refresh fails.
- Cleared the subscriber queue on both success and failure scenarios.
- Preserved the existing refresh architecture.
- Ensured the `isRefreshing` state resets correctly.

## Result
Pending requests now fail gracefully instead of hanging indefinitely after a refresh failure.