### PR TITLE
fix: strict validation and standardized 422 for reminders hours param

### DIFF
--- a/backend/app/routes/reminders.py
+++ b/backend/app/routes/reminders.py
@@ -58,6 +58,16 @@ async def get_upcoming(
     Return all pending reminder alerts for the current user
     within the next `hours` hours (default 24).
     """
+    if not (1 <= hours <= 168):
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "error": "Validation failed",
+                "message": "hours must be between 1 and 168",
+                "field": "hours",
+                "received": hours
+            }
+        )
     reminders = await get_upcoming_reminders(
         user_id=user,
         hours=hours,


### PR DESCRIPTION
## What does this PR do?
Adds explicit server-side validation to the `hours` query parameter 
in `GET /reminders/upcoming`.

## Problem
The `hours` parameter had `ge=1, le=168` but no standardized error 
response. Invalid values like 0, -1, or 9999 didn't return clear, 
structured error messages.

## Fix
- Added explicit `if not (1 <= hours <= 168)` check
- Returns structured 422 with `field`, `message`, and `received` value
- Updated Query description to mention valid range
- Added tests for invalid (0, -1, 169, 9999, abc) and valid (1, 24, 168) inputs

Fixes #24