### PR TITLE
Persist privacy mode to MongoDB — survives server restarts 

### DIFF
--- a/backend/app/routes/privacy.py
+++ b/backend/app/routes/privacy.py
@@ -1,5 +1,4 @@
 from fastapi import APIRouter, Depends
-
 from app.services.auth import get_current_user_id
 from app.services.privacy import is_private, toggle_privacy
 
@@ -8,9 +7,9 @@ router = APIRouter(prefix="/privacy", tags=["privacy"])
 
 @router.get("/")
 async def get_privacy(user_id: str = Depends(get_current_user_id)):
-    return {"private": is_private(user_id)}
+    return {"private": await is_private(user_id)}
 
 
 @router.post("/toggle")
 async def toggle(user_id: str = Depends(get_current_user_id)):
-    return {"private": toggle_privacy(user_id)}
+    return {"private": await toggle_privacy(user_id)}

--- a/backend/app/routes/speaker.py
+++ b/backend/app/routes/speaker.py
@@ -2,17 +2,17 @@ from fastapi import APIRouter, Depends
 from app.models.schema import VoiceTrainRequest
 from app.services.gemini_embedding import get_embedding
 from app.services.speaker_training import add_voice, get_voice_profiles
-from ..services.auth import get_current_user
+from ..services.auth import get_current_user_id
 
 router = APIRouter()
 
 @router.post("/train")
-def train_voice(payload: VoiceTrainRequest, _: dict = Depends(get_current_user)):
+def train_voice(payload: VoiceTrainRequest, _: dict = Depends(get_current_user_id)):
     sample = payload.sample_text or payload.name
     embedding = get_embedding(sample)
     add_voice(payload.name, embedding)
     return {"msg": "voice profile saved", "name": payload.name}
 
 @router.get("/profiles")
-def list_profiles(_: dict = Depends(get_current_user)):
+def list_profiles(_: dict = Depends(get_current_user_id)):
     return {"profiles": get_voice_profiles()}

--- a/backend/app/services/pipeline.py
+++ b/backend/app/services/pipeline.py
@@ -18,7 +18,7 @@ async def process_audio(file_path: str, user_id: str, timestamp: Optional[str] =
     """Process audio file through the complete pipeline with intelligent extraction."""
     try:
         # Check privacy mode
-        if is_private(user_id):
+        if await is_private(user_id):
             logger.info("Privacy mode enabled - skipping processing")
             return None
         

--- a/backend/app/services/privacy.py
+++ b/backend/app/services/privacy.py
@@ -1,12 +1,54 @@
+from app.core.logging_config import logger
+
+# In-memory cache layer — fast path for repeated checks within a process lifetime.
+# Populated lazily from MongoDB on cache miss. Invalidated on toggle.
 _PRIVATE_MODES: dict[str, bool] = {}
 
 
-def toggle_privacy(user_id: str):
-    current_state = _PRIVATE_MODES.get(user_id, False)
+async def toggle_privacy(user_id: str) -> bool:
+    """Toggle privacy mode for a user and persist state to MongoDB."""
+    from app.services.database import get_db
+    db = get_db()
+
+    # Read current state from MongoDB (source of truth)
+    user_doc = await db["users"].find_one(
+        {"username": user_id},
+        {"privacy_enabled": 1}
+    )
+    current_state = user_doc.get("privacy_enabled", False) if user_doc else False
     new_state = not current_state
+
+    # Persist to MongoDB
+    await db["users"].update_one(
+        {"username": user_id},
+        {"$set": {"privacy_enabled": new_state}}
+    )
+
+    # Update in-memory cache
     _PRIVATE_MODES[user_id] = new_state
+    logger.info(f"Privacy mode for user {user_id} set to {new_state}")
     return new_state
 
 
-def is_private(user_id: str):
-    return _PRIVATE_MODES.get(user_id, False)
+async def is_private(user_id: str) -> bool:
+    """
+    Check if privacy mode is enabled for a user.
+    Uses in-memory cache with MongoDB fallback to survive server restarts.
+    """
+    # Cache hit — fast path
+    if user_id in _PRIVATE_MODES:
+        return _PRIVATE_MODES[user_id]
+
+    # Cache miss — query MongoDB (e.g. after server restart)
+    from app.services.database import get_db
+    db = get_db()
+
+    user_doc = await db["users"].find_one(
+        {"username": user_id},
+        {"privacy_enabled": 1}
+    )
+    state = user_doc.get("privacy_enabled", False) if user_doc else False
+
+    # Populate cache
+    _PRIVATE_MODES[user_id] = state
+    return state

--- a/backend/app/services/privacy.py
+++ b/backend/app/services/privacy.py
@@ -21,7 +21,8 @@ async def toggle_privacy(user_id: str) -> bool:
     # Persist to MongoDB
     await db["users"].update_one(
         {"username": user_id},
-        {"$set": {"privacy_enabled": new_state}}
+        {"$set": {"privacy_enabled": new_state}},
+        upsert=True
     )
 
     # Update in-memory cache

--- a/backend/tests/test_privacy.py
+++ b/backend/tests/test_privacy.py
@@ -8,7 +8,6 @@ class TestPrivacy:
     async def test_privacy_endpoints_require_authentication(self, client):
         response = await client.get("/privacy/")
         assert response.status_code == 403
-
         response = await client.post("/privacy/toggle")
         assert response.status_code == 403
 
@@ -29,9 +28,32 @@ class TestPrivacy:
 
     async def test_toggle_privacy_helper_flips_state(self):
         user_id = "helper_user"
-        first_state = toggle_privacy(user_id)
-        second_state = toggle_privacy(user_id)
-
+        first_state = await toggle_privacy(user_id)
+        second_state = await toggle_privacy(user_id)
         assert first_state is True
         assert second_state is False
-        assert is_private(user_id) is False
+        assert await is_private(user_id) is False
+
+    async def test_privacy_persists_after_cache_clear(self):
+        """
+        Verify privacy state survives an in-memory cache wipe (simulates server restart).
+        State must be read from MongoDB, not the local dict.
+        """
+        from app.services import privacy
+
+        user_id = "persistence_test_user"
+
+        # Enable privacy and confirm
+        await toggle_privacy(user_id)
+        assert await is_private(user_id) is True
+
+        # Simulate server restart — wipe in-memory cache entirely
+        privacy._PRIVATE_MODES.clear()
+
+        # State must still be True — read from MongoDB now
+        assert await is_private(user_id) is True
+
+        # Cleanup — toggle back off
+        await toggle_privacy(user_id)
+        privacy._PRIVATE_MODES.clear()
+        assert await is_private(user_id) is False

--- a/backend/tests/test_privacy.py
+++ b/backend/tests/test_privacy.py
@@ -57,3 +57,24 @@ class TestPrivacy:
         await toggle_privacy(user_id)
         privacy._PRIVATE_MODES.clear()
         assert await is_private(user_id) is False
+        
+    async def test_toggle_privacy_for_nonexistent_user_persists_correctly(self):
+        """Verify privacy toggle works even if user doc doesn't exist yet in MongoDB."""
+        from app.services import privacy
+        user_id = "nonexistent_user_test"
+
+        # Clear cache
+        privacy._PRIVATE_MODES.pop(user_id, None)
+
+        # Toggle — should create the field via upsert
+        state = await toggle_privacy(user_id)
+        assert state is True
+
+        # Clear cache and re-read from MongoDB
+        privacy._PRIVATE_MODES.clear()
+        assert await is_private(user_id) is True
+
+        # Cleanup
+        from app.services.database import get_db
+        db = get_db()
+        await db["users"].delete_one({"username": user_id})


### PR DESCRIPTION
## Summary
Fixes the silent privacy mode reset on server restart by persisting state to MongoDB instead of relying on in-memory dict.

Closes #57

## Root Cause
`_PRIVATE_MODES` was a plain Python dict — wiped on every process restart. A user who enabled privacy mode had no indication their preference was lost.

## Changes
- `backend/app/services/privacy.py` — both functions converted to async;   state persisted to `users.privacy_enabled` field in MongoDB; in-memory cache retained as fast path, populated from MongoDB on cache miss
- `backend/app/routes/privacy.py` — added `await` to both calls
- `backend/app/services/pipeline.py` — added `await` to `is_private()` call
- `backend/tests/test_privacy.py` — existing tests updated for async; added `test_privacy_persists_after_cache_clear()` which clears `_PRIVATE_MODES` dict and verifies state is recovered from MongoDB - `backend/app/routes/speaker.py` — fixed broken import (`get_current_user` → `get_current_user_id`) that prevented server startup

## Verified Locally
1. Enable privacy → restart server → privacy still `True` ✅
2. All three existing privacy tests pass ✅
3. New persistence test passes ✅