### PR TITLE
fix(memory_store): store_memories_batch returns mem_ids on success

### DIFF
--- a/backend/app/services/memory_store.py
+++ b/backend/app/services/memory_store.py
@@ -174,16 +174,13 @@ async def store_memories_batch(
             f"Batch ChromaDB upsert failed for user {user_id}, "
             f"rolling back MongoDB batch insert: {e}"
         )
-
-        # Rollback inserted Mongo documents
         await _memories_collection().delete_many({
             "_id": {"$in": mem_ids}
         })
-
         raise
 
-        logger.info(f"Batch stored {len(items)} memories for user {user_id}")
-        return mem_ids
+    logger.info(f"do i Batch stored {len(items)} memories for user {user_id}")
+    return mem_ids
 
 
 # ── Read / Search ─────────────────────────────────────────────────────────────

--- a/backend/tests/test_store_memories_batch.py
+++ b/backend/tests/test_store_memories_batch.py
@@ -1,0 +1,122 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+class TestStoreMemoriesBatch:
+    """Regression tests for store_memories_batch return value fix (#70)."""
+
+    async def test_returns_list_of_uuids_on_success(self, monkeypatch):
+        """store_memories_batch must return a list of N UUIDs, not None."""
+        mock_col = MagicMock()
+        mock_col.insert_many = AsyncMock(return_value=MagicMock())
+
+        mock_chroma_col = MagicMock()
+        mock_chroma_col.upsert = MagicMock()
+
+        monkeypatch.setattr(
+            "app.services.memory_store._memories_collection",
+            lambda: mock_col
+        )
+        monkeypatch.setattr(
+            "app.services.memory_store._get_collection",
+            lambda user_id: mock_chroma_col
+        )
+        monkeypatch.setattr(
+            "app.services.memory_store.get_embeddings_batch",
+            AsyncMock(return_value=[[0.1] * 768, [0.1] * 768])
+        )
+
+        from app.services.memory_store import store_memories_batch
+
+        items = [
+            {"text": "First memory", "metadata": {"intent": "meeting", "speaker": "user", "importance": 0.7}},
+            {"text": "Second memory", "metadata": {"intent": "task", "speaker": "user", "importance": 0.5}},
+        ]
+
+        result = await store_memories_batch(user_id="test_user", items=items)
+
+        assert result is not None, "Expected a list of IDs, got None"
+        assert isinstance(result, list), f"Expected list, got {type(result)}"
+        assert len(result) == 2, f"Expected 2 IDs, got {len(result)}"
+        for mem_id in result:
+            assert isinstance(mem_id, str) and len(mem_id) == 36, (
+                f"Expected UUID string, got: {mem_id}"
+            )
+
+    async def test_returned_ids_match_mongodb_insert(self, monkeypatch):
+        """Returned IDs must match the _id values inserted into MongoDB."""
+        inserted_docs = []
+
+        mock_col = MagicMock()
+        async def capture_insert_many(docs):
+            inserted_docs.extend(docs)
+            return MagicMock()
+        mock_col.insert_many = capture_insert_many
+
+        mock_chroma_col = MagicMock()
+        mock_chroma_col.upsert = MagicMock()
+
+        monkeypatch.setattr(
+            "app.services.memory_store._memories_collection",
+            lambda: mock_col
+        )
+        monkeypatch.setattr(
+            "app.services.memory_store._get_collection",
+            lambda user_id: mock_chroma_col
+        )
+        monkeypatch.setattr(
+            "app.services.memory_store.get_embeddings_batch",
+            AsyncMock(return_value=[[0.1] * 768, [0.1] * 768])
+        )
+
+        from app.services.memory_store import store_memories_batch
+
+        items = [
+            {"text": "Alpha", "metadata": {"intent": "task", "speaker": "user", "importance": 0.6}},
+            {"text": "Beta",  "metadata": {"intent": "task", "speaker": "user", "importance": 0.4}},
+        ]
+
+        result = await store_memories_batch(user_id="test_user", items=items)
+
+        mongo_ids = [doc["_id"] for doc in inserted_docs]
+        assert sorted(result) == sorted(mongo_ids), (
+            f"Returned IDs {result} don't match inserted IDs {mongo_ids}"
+        )
+
+    async def test_rollback_on_chromadb_failure(self, monkeypatch):
+        """On ChromaDB failure, MongoDB docs must be rolled back and exception raised."""
+        mock_col = MagicMock()
+        mock_col.insert_many = AsyncMock(return_value=MagicMock())
+        mock_col.delete_many = AsyncMock(return_value=MagicMock())
+
+        mock_chroma_col = MagicMock()
+        mock_chroma_col.upsert = MagicMock(side_effect=RuntimeError("ChromaDB down"))
+
+        monkeypatch.setattr(
+            "app.services.memory_store._memories_collection",
+            lambda: mock_col
+        )
+        monkeypatch.setattr(
+            "app.services.memory_store._get_collection",
+            lambda user_id: mock_chroma_col
+        )
+        monkeypatch.setattr(
+            "app.services.memory_store.get_embeddings_batch",
+            AsyncMock(return_value=[[0.1] * 768, [0.1] * 768])
+        )
+
+        from app.services.memory_store import store_memories_batch
+
+        items = [
+            {"text": "Memory A", "metadata": {"intent": "meeting", "speaker": "user", "importance": 0.8}},
+            {"text": "Memory B", "metadata": {"intent": "task",    "speaker": "user", "importance": 0.5}},
+        ]
+
+        with pytest.raises(RuntimeError, match="ChromaDB down"):
+            await store_memories_batch(user_id="test_user", items=items)
+
+        mock_col.delete_many.assert_called_once()
+        call_filter = mock_col.delete_many.call_args[0][0]
+        assert "$in" in call_filter.get("_id", {}), (
+            "Rollback delete_many must use $in filter on _id"
+        )


### PR DESCRIPTION
## Problem

`store_memories_batch()` in `backend/app/services/memory_store.py` was silently returning `None` on every successful batch write.

The `logger.info(...)` and `return mem_ids` lines were placed after a bare `raise` inside the `except` block — syntactically valid Python but logically dead code. On the success path, execution fell off the end of the `try/except` and the function implicitly returned `None`.

Any caller relying on the returned IDs for downstream linking, deduplication, or audit received `None` with no error or warning.

## Fix

Moved `logger.info(...)` and `return mem_ids` outside the `except` block so they execute on the success path only. One indentation change, no logic altered.

## Tests

Added `tests/test_store_memories_batch.py` with 3 tests:

- `test_returns_list_of_uuids_on_success` — asserts return value is a list of N UUID strings, not `None`
- `test_returned_ids_match_mongodb_insert` — asserts returned IDs match the `_id` values actually inserted into MongoDB
- `test_rollback_on_chromadb_failure` — asserts ChromaDB failure triggers `delete_many` rollback and propagates the exception

All 3 pass locally.

## Related

Closes #70