### PR TITLE
Configure mobile API URL via Expo env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,10 @@
 .env.local
 .env.*.local
 .env.production
+mobile/.env
+mobile/.env.local
+mobile/.env.*.local
+mobile/.env.production
 # --- Python ---
 __pycache__/
 *.py[cod]

--- a/README.md
+++ b/README.md
@@ -463,14 +463,29 @@ npm run preview
 
 ### Step 6 — Mobile (optional)
 
-Edit `mobile/services/api.js`:
-
-```javascript
-const BASE_URL = "http://192.168.1.XXX:8000";  // your LAN IP, not localhost on device
-```
+Create the mobile environment file:
 
 ```bash
 cd mobile
+cp .env.example .env
+```
+
+Set `EXPO_PUBLIC_API_URL` in `mobile/.env` to the backend URL reachable from the target device:
+
+```env
+# Android emulator
+EXPO_PUBLIC_API_URL=http://10.0.2.2:8000
+
+# iOS simulator or web
+# EXPO_PUBLIC_API_URL=http://localhost:8000
+
+# Physical device on the same Wi-Fi
+# EXPO_PUBLIC_API_URL=http://YOUR_COMPUTER_IP:8000
+```
+
+Restart Expo after changing `.env`.
+
+```bash
 npm install
 npx expo start
 ```
@@ -633,6 +648,8 @@ Tokens are stored in `localStorage` as `verath_token` and `verath_username`.
 | Timeline | `TimelineScreen.js` | Chronological memories |
 | Settings | `SettingsScreen.js` | API URL, preferences |
 | Tabs | `Tabs.js` | Bottom navigation |
+
+**API configuration:** Mobile API requests use `EXPO_PUBLIC_API_URL` from `mobile/.env`. Start from `mobile/.env.example`; do not edit tracked source files for local backend URLs.
 
 **Offline queue:** Failed API calls are stored in AsyncStorage and retried when the network returns (`mobile/services/offlineQueue.js`).
 
@@ -1292,7 +1309,7 @@ eas build --platform ios
 
 | Symptom | Fix |
 |---------|-----|
-| Mobile cannot connect | Use LAN IP in `api.js`, same Wi‑Fi as PC |
+| Mobile cannot connect | Set `EXPO_PUBLIC_API_URL` in `mobile/.env` to a backend URL reachable from the device, then restart Expo |
 | CORS error in browser | Add frontend origin to `ALLOW_CORS` in production |
 | Dashboard 404 after login | Serve `web/legacy/` via Vite or static host |
 

--- a/mobile/.env.example
+++ b/mobile/.env.example
@@ -1,0 +1,5 @@
+# Backend API URL used by the Expo app.
+# Android emulator: http://10.0.2.2:8000
+# iOS simulator or web: http://localhost:8000
+# Physical device: use your computer's LAN IP, for example http://192.168.1.100:8000
+EXPO_PUBLIC_API_URL=http://10.0.2.2:8000

--- a/mobile/config.js
+++ b/mobile/config.js
@@ -1,7 +1,9 @@
-// API Configuration
-// Expo automatically injects variables prefixed with EXPO_PUBLIC_ from .env
-// For Android emulator: Use 'http://10.0.2.2:8000'
-// For physical device on same WiFi: Use 'http://YOUR_COMPUTER_IP:8000'
-// For development on web: Use 'http://localhost:8000'
+const apiUrl = process.env.EXPO_PUBLIC_API_URL?.trim();
 
-export const API_BASE_URL = process.env.EXPO_PUBLIC_API_URL || "http://10.64.200.195:8000";
+if (!apiUrl) {
+  throw new Error(
+    "Missing EXPO_PUBLIC_API_URL. Copy mobile/.env.example to mobile/.env and set it to your backend URL."
+  );
+}
+
+export const API_BASE_URL = apiUrl.replace(/\/+$/, "");


### PR DESCRIPTION
## Summary

- Added `mobile/.env.example` with `EXPO_PUBLIC_API_URL` examples.
- Updated `mobile/config.js` to read the backend URL from Expo public env support.
- Added explicit gitignore coverage for local mobile env files.
- Updated README mobile setup and troubleshooting docs.

## Why

The mobile app had a committed backend URL fallback and docs told contributors to edit source files for local backend addresses. This made onboarding harder and risked accidental commits of personal LAN IPs.

## Impact

Contributors can now configure the mobile backend URL through `mobile/.env` using Expo's standard `EXPO_PUBLIC_*` pattern.

Fixes #66.

## Validation

- `git diff --check`
- `node --check mobile/config.js`
- Confirmed the previous hardcoded IP and README source-edit instructions are removed.