### PR TITLE
fix: isolate speaker profiles per authenticated user

### DIFF
--- a/backend/app/routes/speaker.py
+++ b/backend/app/routes/speaker.py
@@ -7,12 +7,12 @@ from ..services.auth import get_current_user
 router = APIRouter()
 
 @router.post("/train")
-def train_voice(payload: VoiceTrainRequest, _: dict = Depends(get_current_user)):
+def train_voice(payload: VoiceTrainRequest, user: dict = Depends(get_current_user)):
     sample = payload.sample_text or payload.name
     embedding = get_embedding(sample)
-    add_voice(payload.name, embedding)
+    add_voice(user["username"], payload.name, embedding)
     return {"msg": "voice profile saved", "name": payload.name}
 
 @router.get("/profiles")
-def list_profiles(_: dict = Depends(get_current_user)):
-    return {"profiles": get_voice_profiles()}
+def list_profiles(user: dict = Depends(get_current_user)):
+    return {"profiles": get_voice_profiles(user["username"])}

--- a/backend/app/services/pipeline.py
+++ b/backend/app/services/pipeline.py
@@ -53,7 +53,7 @@ async def process_audio(file_path: str, user_id: str, timestamp: Optional[str] =
         
         # Try to map label to a trained voice profile using text embedding
         from app.services.speaker_training import identify_voice
-        identified_name = identify_voice(embedding)
+        identified_name = identify_voice(user_id, embedding)
         
         if identified_name != "unknown":
             primary_speaker = identified_name

--- a/backend/app/services/speaker_training.py
+++ b/backend/app/services/speaker_training.py
@@ -15,9 +15,11 @@ VOICE_DB_JSON = settings.voice_db_path.replace('.pkl', '.json')
 if os.path.exists(VOICE_DB_JSON):
     with open(VOICE_DB_JSON, "r") as file:
         data = json.load(file)
-        voice_profiles: Dict[str, List[float]] = {k: v for k, v in data.items()}
+        voice_profiles: Dict[str, Dict[str, List[float]]] = {
+    k: v for k, v in data.items()
+}
 else:
-    voice_profiles: Dict[str, List[float]] = {}
+    voice_profiles: Dict[str, Dict[str, List[float]]] = {}
 
 
 def save():
@@ -26,10 +28,15 @@ def save():
         json.dump(voice_profiles, file)
 
 
-def add_voice(name: str, embedding: List[float]) -> bool:
+def add_voice(
+    user_id: str,
+    name: str,
+    embedding: List[float]
+) -> bool:
     """Add a new voice profile."""
     try:
-        voice_profiles[name.lower()] = embedding
+        voice_profiles.setdefault(user_id, {})
+        voice_profiles[user_id][name.lower()] = embedding
         save()
         print(f"✅ Added voice profile for '{name}'")
         return True
@@ -38,26 +45,37 @@ def add_voice(name: str, embedding: List[float]) -> bool:
         return False
 
 
-def add_voice_from_text(name: str, text_sample: str) -> bool:
+def add_voice_from_text(
+    user_id: str,
+    name: str,
+    text_sample: str
+) -> bool:
     """Add voice profile from text sample."""
     try:
         embedding = get_embedding(text_sample)
-        return add_voice(name, embedding)
+        return add_voice(user_id, name, embedding)
     except Exception as e:
         print(f"❌ Error processing voice sample: {e}")
         return False
 
 
-def identify_voice(embedding: List[float], threshold: float = 0.8) -> str:
+def identify_voice(
+    user_id: str,
+    embedding: List[float],
+    threshold: float = 0.8
+) -> str:
     """Identify voice from embedding."""
-    if not voice_profiles:
+
+    user_profiles = voice_profiles.get(user_id, {})
+
+    if not user_profiles:
         return "unknown"
 
     best_match = "unknown"
     best_score = -1.0
     query = np.array(embedding, dtype="float32")
 
-    for name, stored_embedding in voice_profiles.items():
+    for name, stored_embedding in user_profiles.items():
         # Convert stored list back to numpy array
         stored = np.array(stored_embedding, dtype="float32")
         # Calculate cosine similarity
@@ -72,22 +90,33 @@ def identify_voice(embedding: List[float], threshold: float = 0.8) -> str:
     return best_match
 
 
-def get_voice_profiles() -> List[str]:
+def get_voice_profiles(user_id: str) -> List[str]:
     """Get list of all trained voice names."""
-    return list(voice_profiles.keys())
+    return list(voice_profiles.get(user_id, {}).keys())
 
-
-def remove_voice_profile(name: str) -> bool:
+def remove_voice_profile(user_id: str, name: str) -> bool:
     """Remove a voice profile."""
     name_lower = name.lower()
-    if name_lower in voice_profiles:
-        del voice_profiles[name_lower]
+
+    if (
+        user_id in voice_profiles
+        and name_lower in voice_profiles[user_id]
+    ):
+        del voice_profiles[user_id][name_lower]
         save()
         print(f"✅ Removed voice profile for '{name}'")
         return True
+
     return False
 
-
-def update_voice_profile(name: str, text_sample: str) -> bool:
+def update_voice_profile(
+    user_id: str,
+    name: str,
+    text_sample: str
+) -> bool:
     """Update existing voice profile."""
-    return add_voice_from_text(name, text_sample)  # Same logic, just overwrites
+    return add_voice_from_text(
+        user_id,
+        name,
+        text_sample
+    )


### PR DESCRIPTION
Closes #75 

## Summary

This PR fixes a multi-user isolation issue in the speaker profile system.

Previously, speaker profiles were stored in a shared global structure, allowing authenticated users to view and overwrite profiles created by other users. Speaker identification could also match against profiles belonging to different users.

## Changes

### User-scoped profile storage

* Updated speaker profile storage to be organized per authenticated user.
* Profiles are now stored and retrieved using the authenticated user's identity.

### User-scoped profile listing

* Updated `/speaker/profiles` to return only profiles belonging to the current user.

### User-scoped profile training

* Updated `/speaker/train` to associate newly trained profiles with the authenticated user.

### User-scoped speaker identification

* Updated speaker recognition logic to search only within the current user's trained profiles.
* Prevents cross-user profile influence during speaker identification.

### Helper updates

* Updated profile management helpers to operate on user-scoped profile data.

## Impact

This resolves:

* Cross-user profile disclosure
* Cross-user profile overwrite/modification
* Lack of tenant isolation between authenticated users
* Cross-user speaker recognition interference

## Validation

Validated locally with:

```bash
python -m py_compile backend/app/routes/speaker.py
python -m py_compile backend/app/services/pipeline.py
python -m py_compile backend/app/services/speaker_training.py
```