### PR TITLE
fix: enforce 50MB file size limit on /record/upload before writing to disk

### DIFF
--- a/backend/app/routes/record.py
+++ b/backend/app/routes/record.py
@@ -49,11 +49,35 @@ async def upload_record(
         # Create a temporary path for the uploaded file
         temp_dir = Path("data/uploads")
         temp_dir.mkdir(parents=True, exist_ok=True)
-        
-        file_path = temp_dir / f"upload_{user_id}_{os.urandom(4).hex()}.wav"
-        
+
+        # Enforce a 50MB file size limit — read the entire upload into
+        # memory in chunks before writing to disk so oversized files are
+        # rejected without filling the disk. shutil.copyfileobj has no
+        # size limit and would write gigabytes before any check ran.
+        MAX_UPLOAD_BYTES = 50 * 1024 * 1024  # 50 MB
+        chunks = []
+        total_bytes = 0
+        chunk_size = 64 * 1024  # 64 KB read buffer
+
+        while True:
+            chunk = await file.read(chunk_size)
+            if not chunk:
+                break
+            total_bytes += len(chunk)
+            if total_bytes > MAX_UPLOAD_BYTES:
+                raise HTTPException(
+                    status_code=413,
+                    detail=f"File too large. Maximum allowed size is "
+                           f"{MAX_UPLOAD_BYTES // (1024 * 1024)} MB.",
+                )
+            chunks.append(chunk)
+
+        file_ext = Path(file.filename or "").suffix.lower() or ".wav"
+        file_path = temp_dir / f"upload_{user_id}_{os.urandom(4).hex()}{file_ext}"
+
         with open(file_path, "wb") as buffer:
-            shutil.copyfileobj(file.file, buffer)
+            for chunk in chunks:
+                buffer.write(chunk)
             
         # Process the saved file, timestamp
         memory = await process_audio(str(file_path), user_id, timestamp=timestamp)


### PR DESCRIPTION
## Description
`/record/upload` used `shutil.copyfileobj` with no size limit:

```python
with open(file_path, "wb") as buffer:
    shutil.copyfileobj(file.file, buffer)
```

Any authenticated user could upload a file of arbitrary size — gigabytes if they chose — which would be fully written to `data/uploads/` before any validation occurred. This is a denial-of-service vector that can exhaust disk space on the server.

Changes made:
- Added a chunked read loop that accumulates upload data in memory using a 64KB read buffer
- Rejects with `HTTP 413 Request Entity Too Large` as soon as `total_bytes` exceeds 50MB — no data is written to disk for oversized files
- The 64KB chunk size avoids blocking the event loop on large uploads while still detecting the limit early
- Also fixed the hardcoded `.wav` extension on saved temp files — now uses the actual extension from `file.filename` so the audio pipeline receives the correct file type
- Works correctly alongside the MIME type and extension validation from PR #81 — size check runs after type validation, before disk write

Fixes #80

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings