### PR TITLE
bug#117 fixed

### DIFF
--- a/backend/app/services/memory_store.py
+++ b/backend/app/services/memory_store.py
@@ -96,6 +96,15 @@ async def store_memory(
             f"rolling back MongoDB insert: {e}"
         )
 
+        # Rollback ChromaDB: remove the vector if it was partially written
+        try:
+            collection.delete(ids=[mem_id])
+        except Exception as chroma_err:
+            logger.error(
+                f"ChromaDB rollback delete also failed for {mem_id}: "
+                f"{chroma_err}"
+            )
+
         # Rollback Mongo insert to maintain consistency
         await _memories_collection().delete_one({"_id": mem_id})
 
@@ -174,6 +183,17 @@ async def store_memories_batch(
             f"Batch ChromaDB upsert failed for user {user_id}, "
             f"rolling back MongoDB batch insert: {e}"
         )
+
+        # Rollback ChromaDB: remove any vectors that were partially written
+        # before the upsert raised. Best-effort — don't mask the original error.
+        try:
+            collection.delete(ids=mem_ids)
+        except Exception as chroma_err:
+            logger.error(
+                f"ChromaDB rollback delete also failed for user {user_id}: "
+                f"{chroma_err}"
+            )
+
         await _memories_collection().delete_many({
             "_id": {"$in": mem_ids}
         })

--- a/backend/tests/test_store_memories_batch.py
+++ b/backend/tests/test_store_memories_batch.py
@@ -91,6 +91,7 @@ class TestStoreMemoriesBatch:
 
         mock_chroma_col = MagicMock()
         mock_chroma_col.upsert = MagicMock(side_effect=RuntimeError("ChromaDB down"))
+        mock_chroma_col.delete = MagicMock()
 
         monkeypatch.setattr(
             "app.services.memory_store._memories_collection",
@@ -115,8 +116,16 @@ class TestStoreMemoriesBatch:
         with pytest.raises(RuntimeError, match="ChromaDB down"):
             await store_memories_batch(user_id="test_user", items=items)
 
+        # Verify MongoDB rollback
         mock_col.delete_many.assert_called_once()
         call_filter = mock_col.delete_many.call_args[0][0]
         assert "$in" in call_filter.get("_id", {}), (
             "Rollback delete_many must use $in filter on _id"
+        )
+
+        # Verify ChromaDB rollback — orphaned vectors must be cleaned up
+        mock_chroma_col.delete.assert_called_once()
+        chroma_delete_ids = mock_chroma_col.delete.call_args.kwargs.get("ids")
+        assert chroma_delete_ids is not None and len(chroma_delete_ids) == 2, (
+            "ChromaDB rollback delete must be called with all mem_ids"
         )


### PR DESCRIPTION
Fix Summary
Bug
When collection.upsert() in ChromaDB partially succeeds then raises an exception (e.g., document-count limits hit mid-batch), the rollback only cleaned up MongoDB via delete_many/delete_one. The vectors already written to ChromaDB were left orphaned — over time these ghosts cause KeyError/None-dereference when vector search returns IDs that no longer exist in MongoDB.

Changes
memory_store.py

store_memories_batch (line ~187–195): Added collection.delete(ids=mem_ids) in the rollback except block, wrapped in a best-effort try/except so that a failed ChromaDB cleanup doesn't mask the original error or prevent the MongoDB rollback.

store_memory (line ~99–106): Applied the same defensive ChromaDB rollback to the single-item path, preventing the same class of orphaned vector even though it's less likely with a single document.

test_store_memories_batch.py

Updated test_rollback_on_chromadb_failure to mock collection.delete and assert it's called with all mem_ids during rollback, so this bug doesn't regress.