### PR TITLE
feat(auth): per-account login lockout to complement IP rate limiting (#55)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,6 +30,8 @@ DATABASE_NAME=verath
 
 # ── Security (required — min 32 characters) ──────────────────────────────────
 SECRET_KEY=change-me-to-a-long-random-secret-key-at-least-32-chars
+LOGIN_MAX_FAILURES=5
+LOGIN_LOCKOUT_MINUTES=15
 
 # ── Audio processing ───────────────────────────────────────────────────────────
 AUDIO_SAMPLE_RATE=16000

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -45,6 +45,15 @@ class Settings(BaseSettings):
         if v in ("your-super-secret-key", "changeme", "secret"):
             raise ValueError("SECRET_KEY is set to a known insecure default — please change it.")
         return v
+    
+    login_max_failures: int = Field(
+        default=5,
+        description="Failed login attempts before an account is locked"
+    )
+    login_lockout_minutes: int = Field(
+        default=15,
+        description="Account lockout duration in minutes"
+    )
 
     # ── LLM Providers (Groq + Gemini Fallback) ──────────────────────────────────
     groq_api_key: str = Field(default="", description="Groq API Key")

--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -16,6 +16,9 @@ from app.services.auth import (
     verify_refresh_token,
     decode_access_token,
     ALGORITHM,
+    get_lockout_seconds_remaining,
+    register_failed_login,
+    reset_login_attempts,
 )
 from app.config import settings
 from app.services.database import get_db
@@ -68,24 +71,38 @@ async def signup(request: Request, credentials: UserCredentials):
 @limiter.limit("10/minute")
 async def login(request: Request, credentials: UserCredentials):
     username_clean = credentials.username.lower().strip()
-    username = await authenticate_user(username_clean, credentials.password)
     ip_address = request.client.host if request.client else "unknown"
-    
+
+    # Account lockout check (per-account, complements IP rate limiting)
+    lock_seconds = await get_lockout_seconds_remaining(username_clean)
+    if lock_seconds > 0:
+        await _log_auth_event(username_clean, ip_address, "login_locked", False)
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail=f"Account temporarily locked. Try again in {lock_seconds} seconds.",
+            headers={"Retry-After": str(lock_seconds)},
+        )
+
+    username = await authenticate_user(username_clean, credentials.password)
+
     # Audit log
     await _log_auth_event(username_clean, ip_address, "login", username is not None)
-    
+
     if not username:
+        await register_failed_login(username_clean)
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid username or password",
             headers={"WWW-Authenticate": "Bearer"},
         )
+
+    await reset_login_attempts(username_clean)
+
     return TokenResponse(
         access_token=create_access_token(username),
         refresh_token=create_refresh_token(username),
         username=username,
     )
-
 
 @router.post("/refresh", response_model=TokenResponse)
 @limiter.limit("20/minute")

--- a/backend/app/services/auth.py
+++ b/backend/app/services/auth.py
@@ -12,11 +12,13 @@ from motor.motor_asyncio import AsyncIOMotorClient
 from app.config import settings
 from app.services.database import get_db
 
+
 logger = logging.getLogger(__name__)
 
 _mongo = AsyncIOMotorClient(settings.mongo_uri)
 _db = _mongo[settings.database_name]
 _users_col = _db["users"]
+_login_attempts_col = _db["login_attempts"]
 
 ACCESS_TOKEN_EXPIRE_MINUTES = 10080  # 7 days in minutes
 REFRESH_TOKEN_EXPIRE_DAYS = 30
@@ -119,6 +121,46 @@ async def authenticate_user(username: str, password: str) -> Optional[str]:
     if not user or not verify_password(password, user["password_hash"]):
         return None
     return username
+
+# ── Account lockout (brute-force protection) ──────────────────────────────────
+async def get_lockout_seconds_remaining(username: str) -> int:
+    """Return seconds remaining on an active lockout, or 0 if not locked."""
+    username = username.lower().strip()
+    record = await _login_attempts_col.find_one({"username": username})
+    if not record:
+        return 0
+    locked_until = record.get("locked_until")
+    if locked_until and locked_until > datetime.utcnow():
+        return int((locked_until - datetime.utcnow()).total_seconds())
+    return 0
+
+
+async def register_failed_login(username: str) -> None:
+    """Record a failed attempt; lock the account once the threshold is hit."""
+    username = username.lower().strip()
+    now = datetime.utcnow()
+    record = await _login_attempts_col.find_one({"username": username})
+    failures = (record.get("failures", 0) if record else 0) + 1
+
+    update = {"failures": failures, "last_failed_at": now}
+    if failures >= settings.login_max_failures:
+        update["locked_until"] = now + timedelta(minutes=settings.login_lockout_minutes)
+        logger.warning(
+            f"AUTH LOCKOUT: account locked - username={username} "
+            f"failures={failures} minutes={settings.login_lockout_minutes}"
+        )
+
+    await _login_attempts_col.update_one(
+        {"username": username},
+        {"$set": update},
+        upsert=True,
+    )
+
+
+async def reset_login_attempts(username: str) -> None:
+    """Clear any failure record on successful authentication."""
+    username = username.lower().strip()
+    await _login_attempts_col.delete_one({"username": username})
 
 
 async def get_user_id_from_username(username: str) -> Optional[str]:

--- a/backend/app/services/database.py
+++ b/backend/app/services/database.py
@@ -59,6 +59,9 @@ async def create_indexes():
         await db["blacklisted_tokens"].create_index("jti", unique=True)
         await db["blacklisted_tokens"].create_index("exp", expireAfterSeconds=0)  # TTL based on token expiry
 
+        await db["login_attempts"].create_index("username", unique=True)
+        await db["login_attempts"].create_index("locked_until", expireAfterSeconds=0)  # auto-cleanup expired lockouts
+        
         # Audit logs
         await db["audit_logs"].create_index([("username", 1), ("timestamp", -1)])
         await db["audit_logs"].create_index([("event_type", 1), ("timestamp", -1)])

--- a/backend/tests/test_account_lockout.py
+++ b/backend/tests/test_account_lockout.py
@@ -1,0 +1,138 @@
+import pytest
+from datetime import datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock
+
+import app.services.auth as auth_service
+
+
+class _FakeAttemptsCollection:
+    """Stateful in-memory stand-in for the login_attempts MongoDB collection.
+
+    Lets the route-level test exercise the full login -> lockout flow without
+    a real Mongo connection while preserving state across requests.
+    """
+
+    def __init__(self):
+        self._records = {}
+
+    async def find_one(self, query):
+        return self._records.get(query["username"])
+
+    async def update_one(self, query, update, upsert=False):
+        username = query["username"]
+        if username not in self._records and upsert:
+            self._records[username] = {"username": username}
+        if username in self._records:
+            self._records[username].update(update.get("$set", {}))
+        return MagicMock(modified_count=1)
+
+    async def delete_one(self, query):
+        existed = self._records.pop(query["username"], None) is not None
+        return MagicMock(deleted_count=1 if existed else 0)
+
+
+class TestAccountLockout:
+    """Per-account login lockout logic in app.services.auth (issue #55)."""
+
+    @pytest.fixture
+    def attempts_col(self, monkeypatch):
+        col = MagicMock()
+        col.find_one = AsyncMock(return_value=None)
+        col.update_one = AsyncMock(return_value=MagicMock(modified_count=1))
+        col.delete_one = AsyncMock(return_value=MagicMock(deleted_count=1))
+        monkeypatch.setattr(auth_service, "_login_attempts_col", col)
+        return col
+
+    async def test_no_record_means_not_locked(self, attempts_col):
+        assert await auth_service.get_lockout_seconds_remaining("alice") == 0
+
+    async def test_active_lockout_returns_seconds_remaining(self, attempts_col):
+        attempts_col.find_one = AsyncMock(return_value={
+            "username": "alice",
+            "failures": 5,
+            "locked_until": datetime.utcnow() + timedelta(minutes=10),
+        })
+        remaining = await auth_service.get_lockout_seconds_remaining("alice")
+        assert 0 < remaining <= 600
+
+    async def test_expired_lockout_returns_zero(self, attempts_col):
+        attempts_col.find_one = AsyncMock(return_value={
+            "username": "alice",
+            "failures": 5,
+            "locked_until": datetime.utcnow() - timedelta(seconds=1),
+        })
+        assert await auth_service.get_lockout_seconds_remaining("alice") == 0
+
+    async def test_failure_below_threshold_increments_without_locking(self, attempts_col, monkeypatch):
+        monkeypatch.setattr(auth_service.settings, "login_max_failures", 5)
+        attempts_col.find_one = AsyncMock(return_value={"username": "alice", "failures": 1})
+
+        await auth_service.register_failed_login("alice")
+
+        set_doc = attempts_col.update_one.call_args[0][1]["$set"]
+        assert set_doc["failures"] == 2
+        assert "locked_until" not in set_doc
+        assert attempts_col.update_one.call_args.kwargs.get("upsert") is True
+
+    async def test_failure_at_threshold_locks_account(self, attempts_col, monkeypatch):
+        monkeypatch.setattr(auth_service.settings, "login_max_failures", 3)
+        monkeypatch.setattr(auth_service.settings, "login_lockout_minutes", 15)
+        attempts_col.find_one = AsyncMock(return_value={"username": "alice", "failures": 2})
+
+        await auth_service.register_failed_login("alice")
+
+        set_doc = attempts_col.update_one.call_args[0][1]["$set"]
+        assert set_doc["failures"] == 3
+        assert "locked_until" in set_doc
+        assert set_doc["locked_until"] > datetime.utcnow()
+
+    async def test_first_failure_on_fresh_account_increments_from_zero(self, attempts_col, monkeypatch):
+        monkeypatch.setattr(auth_service.settings, "login_max_failures", 5)
+        attempts_col.find_one = AsyncMock(return_value=None)
+
+        await auth_service.register_failed_login("alice")
+
+        set_doc = attempts_col.update_one.call_args[0][1]["$set"]
+        assert set_doc["failures"] == 1
+
+    async def test_successful_login_clears_record(self, attempts_col):
+        await auth_service.reset_login_attempts("alice")
+        attempts_col.delete_one.assert_awaited_once_with({"username": "alice"})
+
+    async def test_username_is_normalized(self, attempts_col):
+        await auth_service.get_lockout_seconds_remaining("  ALICE  ")
+        attempts_col.find_one.assert_awaited_once_with({"username": "alice"})
+
+    async def test_login_route_returns_429_after_threshold(self, client, monkeypatch):
+        """End-to-end: failures land 401, the (N+1)th request lands 429 with Retry-After."""
+        fake_col = _FakeAttemptsCollection()
+
+        # Patch in both the service module (where the lockout funcs read the
+        # collection) and the route module (where they were imported by name).
+        monkeypatch.setattr(auth_service, "_login_attempts_col", fake_col)
+        monkeypatch.setattr(auth_service.settings, "login_max_failures", 3)
+        monkeypatch.setattr(auth_service.settings, "login_lockout_minutes", 15)
+
+        async def always_fail(username, password):
+            return None
+
+        # The route does `from app.services.auth import authenticate_user`,
+        # so the live binding is on app.routes.auth — patch it there.
+        monkeypatch.setattr("app.routes.auth.authenticate_user", always_fail)
+
+        for attempt in range(3):
+            resp = await client.post(
+                "/auth/login",
+                json={"username": "bob", "password": "wrong"},
+            )
+            assert resp.status_code == 401, (
+                f"attempt {attempt + 1} should be 401, got {resp.status_code}: {resp.text}"
+            )
+
+        resp = await client.post(
+            "/auth/login",
+            json={"username": "bob", "password": "wrong"},
+        )
+        assert resp.status_code == 429
+        assert "Retry-After" in resp.headers
+        assert int(resp.headers["Retry-After"]) > 0


### PR DESCRIPTION
Closes #55.

Adds a per-account login lockout that complements the existing slowapi IP rate limiting. After N failed login attempts on a username (regardless of source IP), the account is locked for a cooldown window and `/login` returns 429 with a `Retry-After` header. The counter resets on a successful login.

**What changed**

- `backend/app/config.py` — two new settings: `login_max_failures` (default 5) and `login_lockout_minutes` (default 15), reachable via `.env`.
- `backend/app/services/auth.py` - three async helpers next to the existing user logic: `get_lockout_seconds_remaining`, `register_failed_login`, `reset_login_attempts`. Backed by a new `login_attempts` MongoDB collection (`{username, failures, last_failed_at, locked_until}`). Matches the file's `datetime.utcnow()` and `username.lower().strip()` conventions.
- `backend/app/routes/auth.py` - `/login` now checks lockout first, then authenticates, registers a failure before raising 401, and resets attempts before issuing tokens on success. `signup`, `refresh`, and `logout` are unchanged.
- `backend/app/services/database.py` - `login_attempts` indexes: unique on `username` and a TTL on `locked_until`, mirroring the existing `blacklisted_tokens` pattern.
- `.env.example` - `LOGIN_MAX_FAILURES` and `LOGIN_LOCKOUT_MINUTES` documented.
- `backend/tests/test_account_lockout.py` - 9 tests: not-locked when no record, active lockout returns remaining seconds, expired lockout returns 0, below-threshold increments without locking, threshold locks the account, first failure on a fresh account increments from 0, success clears the record, username normalization, and an end-to-end route test asserting 429 + `Retry-After` after the threshold.

**Design note worth flagging**

While `locked_until > now()`, login is rejected with 429 regardless of whether the password is correct. The reset only fires on a successful auth that isn't currently locked. This is the secure reading — if a correct password during the lockout window cleared the counter, an attacker who eventually guesses right mid-window would escape the lockout. Happy to switch behavior if a different intent was meant.

**Note on rebase**

Originally branched off `main` before #85 (refresh token rotation) landed. After rebasing onto current `main`, the only conflict was in the `routes/auth.py` import block - kept both upstream's `ALGORITHM` import (used by the new refresh-rotation logic) and the three new lockout names. All 9 tests pass against post-rebase main.