### PR TITLE
fix(validators): use model_validator so max_length check works (#133)

### DIFF
--- a/backend/app/core/validators.py
+++ b/backend/app/core/validators.py
@@ -1,6 +1,6 @@
 import re
 from typing import Optional, List
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, model_validator 
 from fastapi import HTTPException, status
 from pathlib import Path
 from app.core.logging_config import logger
@@ -10,45 +10,45 @@ class TextInputValidator(BaseModel):
     """Validator for text inputs to prevent injection attacks."""
     text: str
     max_length: int = 10000
-    
-    @field_validator('text')
-    @classmethod
-    def validate_text(cls, v):
-        if not v or not v.strip():
+
+    @model_validator(mode="after")
+    def validate_text(self):
+        if not self.text or not self.text.strip():
             raise ValueError("Text cannot be empty")
-        
-        if len(v) > cls.max_length:
-            raise ValueError(f"Text exceeds maximum length of {cls.max_length}")
-        
+
+        if len(self.text) > self.max_length:
+            raise ValueError(f"Text exceeds maximum length of {self.max_length}")
+
         # Check for potential injection patterns
         dangerous_patterns = [
             r'<script.*?>.*?</script>',
             r'javascript:',
             r'on\w+\s*=',
         ]
-        
+
         for pattern in dangerous_patterns:
-            if re.search(pattern, v, re.IGNORECASE):
+            if re.search(pattern, self.text, re.IGNORECASE):
                 raise ValueError("Text contains potentially dangerous content")
-        
-        return v.strip()
+
+        self.text = self.text.strip()
+        return self
 
 
 class QueryValidator(BaseModel):
     """Validator for query inputs."""
     query: str
     max_length: int = 500
-    
-    @field_validator('query')
-    @classmethod
-    def validate_query(cls, v):
-        if not v or not v.strip():
+
+    @model_validator(mode="after")
+    def validate_query(self):
+        if not self.query or not self.query.strip():
             raise ValueError("Query cannot be empty")
-        
-        if len(v) > cls.max_length:
-            raise ValueError(f"Query exceeds maximum length of {cls.max_length}")
-        
-        return v.strip()
+
+        if len(self.query) > self.max_length:
+            raise ValueError(f"Query exceeds maximum length of {self.max_length}")
+
+        self.query = self.query.strip()
+        return self
 
 
 def sanitize_filename(filename: str) -> str:

--- a/backend/app/routes/speaker.py
+++ b/backend/app/routes/speaker.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, Depends
 from app.models.schema import VoiceTrainRequest
 from app.services.gemini_embedding import get_embedding
 from app.services.speaker_training import add_voice, get_voice_profiles
-from ..services.auth import get_current_user_id
+from ..services.auth import get_current_user_id, get_current_user
 
 router = APIRouter()
 

--- a/backend/tests/test_validators.py
+++ b/backend/tests/test_validators.py
@@ -1,0 +1,46 @@
+import pytest
+from pydantic import ValidationError
+
+from app.core.validators import TextInputValidator, QueryValidator
+
+
+class TestTextInputValidator:
+    def test_accepts_valid_text(self):
+        # Regression: this previously raised AttributeError: max_length
+        v = TextInputValidator(text="hello world")
+        assert v.text == "hello world"
+
+    def test_strips_whitespace(self):
+        v = TextInputValidator(text="  spaced  ")
+        assert v.text == "spaced"
+
+    def test_enforces_custom_max_length(self):
+        with pytest.raises(ValidationError):
+            TextInputValidator(text="x" * 30, max_length=5)
+
+    def test_rejects_empty_text(self):
+        with pytest.raises(ValidationError):
+            TextInputValidator(text="   ")
+
+    @pytest.mark.parametrize("payload", [
+        "<script>alert(1)</script>",
+        "javascript:alert(1)",
+        "<img onerror=alert(1)>",
+    ])
+    def test_rejects_injection_patterns(self, payload):
+        with pytest.raises(ValidationError):
+            TextInputValidator(text=payload)
+
+
+class TestQueryValidator:
+    def test_accepts_valid_query(self):
+        v = QueryValidator(query="find my notes")
+        assert v.query == "find my notes"
+
+    def test_enforces_custom_max_length(self):
+        with pytest.raises(ValidationError):
+            QueryValidator(query="x" * 30, max_length=5)
+
+    def test_rejects_empty_query(self):
+        with pytest.raises(ValidationError):
+            QueryValidator(query="   ")


### PR DESCRIPTION
## Summary

Fixes #133. `TextInputValidator` and `QueryValidator` in `backend/app/core/validators.py` accessed `cls.max_length` inside a `@field_validator`. In Pydantic v2, `cls` inside a field validator is the model class, and a field name isn't accessible there as a plain attribute - so `cls.max_length` raises `AttributeError` on every non-empty input. Both validators were effectively broken; any input that passed the empty-check crashed instead of validating.

Switched both to `@model_validator(mode="after")` reading `self.max_length` / `self.text` (and `self.query`). This preserves all the original behavior - empty rejection, the injection-pattern checks, whitespace stripping — while actually honoring a custom `max_length`.

## Changes

- `backend/app/core/validators.py`: rewrote `TextInputValidator.validate_text` and `QueryValidator.validate_query` as `model_validator(mode="after")`. Swapped the unused `field_validator` import for `model_validator`.
- `backend/tests/test_validators.py`: new unit tests - valid input is accepted, custom `max_length` is enforced, empty input is rejected, and the three injection patterns (`<script>`, `javascript:`, `on*=`) are rejected. Parallel coverage for `QueryValidator`.
- `backend/app/routes/speaker.py`: fixed an unrelated import error that was blocking the test suite. The file imported `get_current_user_id` but referenced the undefined name `get_current_user` in two route signatures, raising `NameError` at import time and crashing `app.main` (which `conftest.py` imports). Imported the correct name from `app.services.auth`, where both functions are defined. Flagging this explicitly since it's outside the validator scope - happy to split it into its own PR if you'd prefer.

## Testing

`pytest tests/test_validators.py -v` → 10 passed. The validators now construct correctly (verified `TextInputValidator(text="hello world")` returns the value instead of raising), enforce custom limits, and reject empty/dangerous input.

## Notes

The validators aren't imported anywhere in the backend yet, so this was a latent bug - but it would have surfaced the moment either validator was wired into a route. The fix makes them usable.