### PR TITLE
fix: clear lru_cache on transcription error to allow model reload

### DIFF
--- a/backend/app/services/transcription.py
+++ b/backend/app/services/transcription.py
@@ -36,4 +36,10 @@ def transcribe(audio_path: str) -> str:
         return text
     except Exception as e:
         logger.error(f"Transcription error: {e}")
+        # Clear the lru_cache so the next call attempts to reload the model
+        # rather than reusing a potentially corrupted or stale instance.
+        # Without this, a model that enters an error state (e.g. GPU OOM)
+        # is used indefinitely for the lifetime of the process.
+        get_model.cache_clear()
+        logger.info("Whisper model cache cleared — will reload on next transcription attempt.")
         raise


### PR DESCRIPTION
## Description
`transcription.py` cached the Whisper model with `@lru_cache(maxsize=1)` with no invalidation mechanism:

```python
@lru_cache(maxsize=1)
def get_model() -> WhisperModel:
    ...
    return WhisperModel(settings.whisper_model, ...)
```

If the Whisper model entered an error state after initial load (e.g. GPU OOM, model corruption, exhausted memory mid-session), all subsequent `transcribe()` calls reused the same broken instance indefinitely for the lifetime of the process. There was no recovery path short of restarting the entire server.

Changes made:
- Added `get_model.cache_clear()` in the `except` block of `transcribe()` — evicts the cached model instance when a transcription error occurs
- The next call to `transcribe()` will call `get_model()` again and reload a fresh model instance
- Added `logger.info` to make the cache clear visible in server logs for observability
- The `lru_cache` is preserved for normal operation — the model is still cached and reused across successful transcription calls

Fixes #110

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings