### PR TITLE
 doc: add privacy-focused Code of Conduct for Verath contributors

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,73 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as contributors, maintainers, and community members pledge to make participation in the Verath community a respectful, welcoming, and harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+We are committed to fostering an open, inclusive, and collaborative environment where contributors can learn, innovate, and build meaningful technology together.
+
+## Our Standards
+
+Examples of behavior that contribute to a positive environment include:
+
+* Treating all community members with respect and professionalism.
+* Providing constructive feedback and accepting feedback gracefully.
+* Being welcoming and supportive of contributors of all experience levels.
+* Sharing knowledge and collaborating openly.
+* Respecting differing viewpoints, experiences, and ideas.
+* Prioritizing user privacy, responsible AI practices, and ethical development.
+
+Examples of unacceptable behavior include:
+
+* Harassment, discrimination, or hateful conduct of any kind.
+* Trolling, insulting, or derogatory comments.
+* Personal attacks or intimidation.
+* Publishing private or sensitive information without permission.
+* Misusing project resources for harmful, deceptive, or malicious purposes.
+* Any conduct that creates an unsafe, hostile, or unwelcoming environment.
+
+## Privacy and Responsible AI
+
+As Verath is designed to process personal memories, voice recordings, and structured information, contributors are expected to respect privacy and handle user data responsibly.
+
+Contributors should:
+
+* Avoid exposing sensitive user information in issues, pull requests, or discussions.
+* Follow responsible AI and data-handling practices.
+* Respect confidentiality when working with example datasets or test data.
+* Prioritize security and privacy when proposing new features or improvements.
+
+## Enforcement Responsibilities
+
+Project maintainers are responsible for clarifying and enforcing community standards and may take appropriate corrective action in response to unacceptable behavior.
+
+Maintainers reserve the right to remove, edit, or reject comments, commits, code, issues, pull requests, and other contributions that do not align with this Code of Conduct.
+
+## Scope
+
+This Code of Conduct applies within all project spaces, including GitHub repositories, issues, pull requests, discussions, documentation, community chats, and other communication channels related to Verath.
+
+It also applies when an individual is officially representing the project in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the project maintainers.
+
+All reports will be reviewed and investigated fairly, promptly, and confidentially whenever possible.
+
+## Consequences
+
+Project maintainers may take actions including:
+
+* Private warnings
+* Temporary restrictions on participation
+* Removal of content that violates community standards
+* Temporary or permanent bans from project spaces
+
+depending on the severity and frequency of violations.
+
+## Attribution
+
+This Code of Conduct is adapted from the Contributor Covenant, version 2.1:
+
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html


### PR DESCRIPTION
added a comprehensive CODE_OF_CONDUCT.md that establishes community standards, contributor expectations, responsible AI practices, and privacy-focused guidelines for the Verath project. The document promotes respectful collaboration while emphasizing the secure and ethical handling of user memories, voice recordings, and personal data. Closes issue #137 .