### PR TITLE
fix: reset refreshing state on timeline fetch failure

### DIFF
--- a/mobile/screens/TimelineScreen.js
+++ b/mobile/screens/TimelineScreen.js
@@ -31,11 +31,16 @@ export default function TimelineScreen() {
   };
 
   const onRefresh = async () => {
-    setRefreshing(true);
+  setRefreshing(true);
+  try {
     const data = await getTimeline();
     setEvents(data.timeline || []);
+  } catch (e) {
+    setError('Failed to refresh timeline');
+  } finally {
     setRefreshing(false);
-  };
+  }
+};
 
   const playAudio = async (audioFile, eventId) => {
     try {


### PR DESCRIPTION
## Summary
Fixed the Timeline screen's pull-to-refresh handler so the refreshing 
state is always reset, even when the API request fails.

`onRefresh` previously called `setRefreshing(false)` only after a 
successful response. If `getTimeline()` threw an exception, the spinner 
remained active indefinitely. Wrapped the logic in `try...catch...finally` 
so `setRefreshing(false)` always executes, and added error handling via 
the existing `setError` state consistent with `fetchTimeline`.

## Test plan
- [ ] Simulated failed timeline request (network disabled) — spinner stops correctly
- [ ] Successful refresh behavior unchanged

Fixes #139