### PR TITLE
feat: add offline RAG retrieval evaluation benchmark

### DIFF
--- a/backend/app/evaluation/README.md
+++ b/backend/app/evaluation/README.md
@@ -1,0 +1,17 @@
+# Retrieval Evaluation Benchmark
+
+## Overview
+
+This benchmark evaluates retrieval quality using deterministic synthetic memory datasets.
+
+## Metrics
+
+- Recall@K
+- Precision@K
+- Mean Reciprocal Rank (MRR)
+- Source-hit Accuracy
+
+## Running
+
+```bash
+PYTHONPATH=. python -m app.evaluation.rag_benchmark

--- a/backend/app/evaluation/__init__.py
+++ b/backend/app/evaluation/__init__.py
@@ -1,0 +1,1 @@
+"""Offline retrieval evaluation utilities for Verath."""

--- a/backend/app/evaluation/data/rag_eval_queries.json
+++ b/backend/app/evaluation/data/rag_eval_queries.json
@@ -11,12 +11,42 @@
   },
   {
     "query_id": "q_003",
-    "query": "What open-source utility did the user add for CSV files?",
+    "query": "What CSV utility did the user add?",
     "expected_memory_ids": ["mem_003"]
   },
   {
     "query_id": "q_004",
-    "query": "Which Verilog project involved emergency vehicle priority?",
+    "query": "Which project involved emergency vehicle priority?",
     "expected_memory_ids": ["mem_004"]
+  },
+  {
+    "query_id": "q_005",
+    "query": "When is the doctor appointment?",
+    "expected_memory_ids": ["mem_005"]
+  },
+  {
+    "query_id": "q_006",
+    "query": "What groceries need to be bought?",
+    "expected_memory_ids": ["mem_006"]
+  },
+  {
+    "query_id": "q_007",
+    "query": "Who is the project planning meeting with?",
+    "expected_memory_ids": ["mem_007"]
+  },
+  {
+    "query_id": "q_008",
+    "query": "Where is the vacation planned?",
+    "expected_memory_ids": ["mem_008"]
+  },
+  {
+    "query_id": "q_009",
+    "query": "Which assignment must be submitted before Friday evening?",
+    "expected_memory_ids": ["mem_009"]
+  },
+  {
+    "query_id": "q_010",
+    "query": "Which workshop did the user attend in Bhubaneswar?",
+    "expected_memory_ids": ["mem_010"]
   }
 ]

--- a/backend/app/evaluation/data/rag_eval_queries.json
+++ b/backend/app/evaluation/data/rag_eval_queries.json
@@ -1,0 +1,22 @@
+[
+  {
+    "query_id": "q_001",
+    "query": "Which company provided the user's VLSI internship?",
+    "expected_memory_ids": ["mem_001"]
+  },
+  {
+    "query_id": "q_002",
+    "query": "What technical areas is the user interested in?",
+    "expected_memory_ids": ["mem_002"]
+  },
+  {
+    "query_id": "q_003",
+    "query": "What open-source utility did the user add for CSV files?",
+    "expected_memory_ids": ["mem_003"]
+  },
+  {
+    "query_id": "q_004",
+    "query": "Which Verilog project involved emergency vehicle priority?",
+    "expected_memory_ids": ["mem_004"]
+  }
+]

--- a/backend/app/evaluation/data/synthetic_memories.json
+++ b/backend/app/evaluation/data/synthetic_memories.json
@@ -1,42 +1,52 @@
 [
   {
     "memory_id": "mem_001",
-    "content": "User completed a Digital Electronics and VLSI internship at Codec Technologies and received a certificate and letter of recommendation.",
-    "metadata": {
-      "category": "internship",
-      "date": "2026-06-03",
-      "entities": ["Codec Technologies", "Digital Electronics", "VLSI", "certificate", "letter of recommendation"],
-      "source": "synthetic"
-    }
+    "content": "User completed a Digital Electronics and VLSI internship at Codec Technologies.",
+    "metadata": {"category": "internship", "date": "2026-06-03"}
   },
   {
     "memory_id": "mem_002",
-    "content": "User is interested in IoT, artificial intelligence, machine learning, and open-source contributions.",
-    "metadata": {
-      "category": "profile",
-      "date": "2026-06-02",
-      "entities": ["IoT", "AI", "ML", "open-source"],
-      "source": "synthetic"
-    }
+    "content": "User is interested in IoT, AI, machine learning, and open-source.",
+    "metadata": {"category": "profile"}
   },
   {
     "memory_id": "mem_003",
-    "content": "User contributed to an open-source project by adding a CSV validation utility for malformed rows and inconsistent columns.",
-    "metadata": {
-      "category": "open_source",
-      "date": "2026-05-25",
-      "entities": ["CSV validation", "open-source", "malformed rows"],
-      "source": "synthetic"
-    }
+    "content": "User added a CSV validation utility for malformed rows and inconsistent columns.",
+    "metadata": {"category": "open_source"}
   },
   {
     "memory_id": "mem_004",
-    "content": "User built a Verilog traffic light controller with emergency vehicle priority using Vivado.",
-    "metadata": {
-      "category": "hardware_project",
-      "date": "2026-05-24",
-      "entities": ["Verilog", "traffic light controller", "Vivado", "emergency vehicle priority"],
-      "source": "synthetic"
-    }
+    "content": "User built a Verilog traffic light controller with emergency vehicle priority.",
+    "metadata": {"category": "project"}
+  },
+  {
+    "memory_id": "mem_005",
+    "content": "Doctor appointment is scheduled for July 14 at 3 PM at City Clinic.",
+    "metadata": {"category": "reminder", "date": "2026-07-14", "location": "City Clinic"}
+  },
+  {
+    "memory_id": "mem_006",
+    "content": "Buy groceries including milk, eggs, and bread on Saturday.",
+    "metadata": {"category": "task"}
+  },
+  {
+    "memory_id": "mem_007",
+    "content": "Meeting with Rahul about project planning is scheduled for Monday.",
+    "metadata": {"category": "meeting", "person": "Rahul"}
+  },
+  {
+    "memory_id": "mem_008",
+    "content": "Vacation is planned in Goa during December.",
+    "metadata": {"category": "travel", "location": "Goa"}
+  },
+  {
+    "memory_id": "mem_009",
+    "content": "Submit DBMS assignment before Friday evening.",
+    "metadata": {"category": "reminder"}
+  },
+  {
+    "memory_id": "mem_010",
+    "content": "User attended an edge computing and Industrial IoT workshop in Bhubaneswar.",
+    "metadata": {"category": "event", "location": "Bhubaneswar"}
   }
 ]

--- a/backend/app/evaluation/data/synthetic_memories.json
+++ b/backend/app/evaluation/data/synthetic_memories.json
@@ -1,0 +1,42 @@
+[
+  {
+    "memory_id": "mem_001",
+    "content": "User completed a Digital Electronics and VLSI internship at Codec Technologies and received a certificate and letter of recommendation.",
+    "metadata": {
+      "category": "internship",
+      "date": "2026-06-03",
+      "entities": ["Codec Technologies", "Digital Electronics", "VLSI", "certificate", "letter of recommendation"],
+      "source": "synthetic"
+    }
+  },
+  {
+    "memory_id": "mem_002",
+    "content": "User is interested in IoT, artificial intelligence, machine learning, and open-source contributions.",
+    "metadata": {
+      "category": "profile",
+      "date": "2026-06-02",
+      "entities": ["IoT", "AI", "ML", "open-source"],
+      "source": "synthetic"
+    }
+  },
+  {
+    "memory_id": "mem_003",
+    "content": "User contributed to an open-source project by adding a CSV validation utility for malformed rows and inconsistent columns.",
+    "metadata": {
+      "category": "open_source",
+      "date": "2026-05-25",
+      "entities": ["CSV validation", "open-source", "malformed rows"],
+      "source": "synthetic"
+    }
+  },
+  {
+    "memory_id": "mem_004",
+    "content": "User built a Verilog traffic light controller with emergency vehicle priority using Vivado.",
+    "metadata": {
+      "category": "hardware_project",
+      "date": "2026-05-24",
+      "entities": ["Verilog", "traffic light controller", "Vivado", "emergency vehicle priority"],
+      "source": "synthetic"
+    }
+  }
+]

--- a/backend/app/evaluation/rag_benchmark.py
+++ b/backend/app/evaluation/rag_benchmark.py
@@ -1,0 +1,244 @@
+"""Deterministic offline retrieval benchmark utilities.
+
+This module intentionally avoids external LLM providers, API keys, and
+production retrieval behavior changes. It evaluates ranked memory IDs against
+version-controlled synthetic expected mappings.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import re
+from pathlib import Path
+from typing import Any, Callable
+
+
+BASE_DIR = Path(__file__).resolve().parent
+DEFAULT_MEMORIES_PATH = BASE_DIR / "data" / "synthetic_memories.json"
+DEFAULT_QUERIES_PATH = BASE_DIR / "data" / "rag_eval_queries.json"
+
+
+Retriever = Callable[[str, list[dict[str, Any]], int], list[str]]
+
+
+def load_json(path: str | Path) -> Any:
+    """Load JSON data from disk."""
+    with Path(path).open("r", encoding="utf-8") as file:
+        return json.load(file)
+
+
+def _tokenize(text: str) -> set[str]:
+    """Tokenize text deterministically for the local baseline retriever."""
+    return set(re.findall(r"[a-z0-9]+", text.lower()))
+
+
+def deterministic_keyword_retriever(
+    query: str,
+    memories: list[dict[str, Any]],
+    top_k: int,
+) -> list[str]:
+    """Return ranked memory IDs using deterministic lexical overlap.
+
+    This is only a local baseline/demo retriever. The benchmark can also accept
+    a project retriever adapter without changing production retrieval behavior.
+    """
+    query_tokens = _tokenize(query)
+    scored: list[tuple[int, str]] = []
+
+    for memory in memories:
+        memory_id = memory["memory_id"]
+        content = memory.get("content", "")
+        metadata = memory.get("metadata", {})
+        metadata_text = " ".join(
+            str(value) if not isinstance(value, list) else " ".join(map(str, value))
+            for value in metadata.values()
+        )
+        memory_tokens = _tokenize(f"{content} {metadata_text}")
+        overlap = len(query_tokens & memory_tokens)
+        scored.append((overlap, memory_id))
+
+    scored.sort(key=lambda item: (-item[0], item[1]))
+    return [memory_id for score, memory_id in scored[:top_k] if score > 0]
+
+
+def recall_at_k(expected_ids: set[str], retrieved_ids: list[str], k: int) -> float:
+    """Calculate Recall@K."""
+    if not expected_ids:
+        return 0.0
+
+    top_k = set(retrieved_ids[:k])
+    return len(expected_ids & top_k) / len(expected_ids)
+
+
+def precision_at_k(expected_ids: set[str], retrieved_ids: list[str], k: int) -> float:
+    """Calculate Precision@K."""
+    if k <= 0:
+        return 0.0
+
+    top_k = retrieved_ids[:k]
+    if not top_k:
+        return 0.0
+
+    return len(expected_ids & set(top_k)) / k
+
+
+def reciprocal_rank(expected_ids: set[str], retrieved_ids: list[str]) -> float:
+    """Calculate reciprocal rank for the first relevant retrieved result."""
+    for rank, memory_id in enumerate(retrieved_ids, start=1):
+        if memory_id in expected_ids:
+            return 1.0 / rank
+
+    return 0.0
+
+
+def source_hit_at_k(expected_ids: set[str], retrieved_ids: list[str], k: int) -> int:
+    """Return 1 if at least one expected source appears in top K."""
+    return int(bool(expected_ids & set(retrieved_ids[:k])))
+
+
+def evaluate_single_query(
+    expected_ids: list[str],
+    retrieved_ids: list[str],
+    k_values: tuple[int, ...] = (1, 5),
+) -> dict[str, float | int]:
+    """Evaluate one query's ranked retrieval output."""
+    expected_set = set(expected_ids)
+    metrics: dict[str, float | int] = {
+        "mrr": reciprocal_rank(expected_set, retrieved_ids),
+    }
+
+    for k in k_values:
+        metrics[f"recall@{k}"] = recall_at_k(expected_set, retrieved_ids, k)
+        metrics[f"precision@{k}"] = precision_at_k(expected_set, retrieved_ids, k)
+        metrics[f"source_hit@{k}"] = source_hit_at_k(expected_set, retrieved_ids, k)
+
+    return metrics
+
+
+def evaluate_retriever(
+    memories: list[dict[str, Any]],
+    queries: list[dict[str, Any]],
+    retriever: Retriever = deterministic_keyword_retriever,
+    top_k: int = 5,
+    k_values: tuple[int, ...] = (1, 5),
+) -> dict[str, Any]:
+    """Run retrieval evaluation over all benchmark queries."""
+    per_query_results = []
+
+    for query_item in queries:
+        retrieved_ids = retriever(query_item["query"], memories, top_k)
+        metrics = evaluate_single_query(
+            expected_ids=query_item["expected_memory_ids"],
+            retrieved_ids=retrieved_ids,
+            k_values=k_values,
+        )
+
+        per_query_results.append(
+            {
+                "query_id": query_item["query_id"],
+                "query": query_item["query"],
+                "expected_memory_ids": query_item["expected_memory_ids"],
+                "retrieved_memory_ids": retrieved_ids,
+                "metrics": metrics,
+            }
+        )
+
+    aggregate: dict[str, float] = {}
+    if per_query_results:
+        metric_names = per_query_results[0]["metrics"].keys()
+        for metric_name in metric_names:
+            aggregate[metric_name] = sum(
+                float(item["metrics"][metric_name]) for item in per_query_results
+            ) / len(per_query_results)
+
+    return {
+        "num_queries": len(queries),
+        "top_k": top_k,
+        "aggregate_metrics": aggregate,
+        "per_query": per_query_results,
+    }
+
+
+def save_json_report(report: dict[str, Any], output_path: str | Path) -> None:
+    """Save benchmark report as JSON."""
+    path = Path(output_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    with path.open("w", encoding="utf-8") as file:
+        json.dump(report, file, indent=2)
+
+
+def save_csv_report(report: dict[str, Any], output_path: str | Path) -> None:
+    """Save per-query benchmark results as CSV."""
+    path = Path(output_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    metric_names = sorted(report["aggregate_metrics"].keys())
+
+    with path.open("w", newline="", encoding="utf-8") as file:
+        writer = csv.DictWriter(
+            file,
+            fieldnames=[
+                "query_id",
+                "query",
+                "expected_memory_ids",
+                "retrieved_memory_ids",
+                *metric_names,
+            ],
+        )
+        writer.writeheader()
+
+        for item in report["per_query"]:
+            row = {
+                "query_id": item["query_id"],
+                "query": item["query"],
+                "expected_memory_ids": ",".join(item["expected_memory_ids"]),
+                "retrieved_memory_ids": ",".join(item["retrieved_memory_ids"]),
+            }
+            row.update(item["metrics"])
+            writer.writerow(row)
+
+
+def run_benchmark(
+    memories_path: str | Path = DEFAULT_MEMORIES_PATH,
+    queries_path: str | Path = DEFAULT_QUERIES_PATH,
+    top_k: int = 5,
+) -> dict[str, Any]:
+    """Run the default deterministic benchmark."""
+    memories = load_json(memories_path)
+    queries = load_json(queries_path)
+    return evaluate_retriever(memories=memories, queries=queries, top_k=top_k)
+
+
+def main() -> None:
+    """CLI entry point for the offline benchmark."""
+    parser = argparse.ArgumentParser(
+        description="Run deterministic offline retrieval evaluation benchmark."
+    )
+    parser.add_argument("--memories", default=str(DEFAULT_MEMORIES_PATH))
+    parser.add_argument("--queries", default=str(DEFAULT_QUERIES_PATH))
+    parser.add_argument("--top-k", type=int, default=5)
+    parser.add_argument("--json-output", default="")
+    parser.add_argument("--csv-output", default="")
+
+    args = parser.parse_args()
+
+    report = run_benchmark(
+        memories_path=args.memories,
+        queries_path=args.queries,
+        top_k=args.top_k,
+    )
+
+    print(json.dumps(report["aggregate_metrics"], indent=2))
+
+    if args.json_output:
+        save_json_report(report, args.json_output)
+
+    if args.csv_output:
+        save_csv_report(report, args.csv_output)
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/app/evaluation/retrieval_adapter.py
+++ b/backend/app/evaluation/retrieval_adapter.py
@@ -1,0 +1,18 @@
+"""
+Adapter layer for benchmark integration.
+
+Current implementation uses the deterministic retriever.
+Future contributors can replace this with Verath's
+actual retrieval/query pipeline without modifying
+benchmark logic.
+"""
+
+from app.evaluation.rag_benchmark import deterministic_keyword_retriever
+
+
+def retrieve(query, memories, top_k=5):
+    return deterministic_keyword_retriever(
+        query=query,
+        memories=memories,
+        top_k=top_k,
+    )

--- a/backend/tests/test_rag_benchmark.py
+++ b/backend/tests/test_rag_benchmark.py
@@ -1,0 +1,178 @@
+from pathlib import Path
+
+from app.evaluation.rag_benchmark import (
+    deterministic_keyword_retriever,
+    evaluate_retriever,
+    evaluate_single_query,
+    load_json,
+    precision_at_k,
+    recall_at_k,
+    reciprocal_rank,
+    save_csv_report,
+    save_json_report,
+    source_hit_at_k,
+)
+
+
+def test_recall_at_k():
+    expected = {"mem_001", "mem_002"}
+    retrieved = ["mem_003", "mem_001", "mem_004"]
+
+    assert recall_at_k(expected, retrieved, 1) == 0.0
+    assert recall_at_k(expected, retrieved, 2) == 0.5
+    assert recall_at_k(expected, retrieved, 5) == 0.5
+
+
+def test_precision_at_k():
+    expected = {"mem_001"}
+    retrieved = ["mem_003", "mem_001", "mem_004"]
+
+    assert precision_at_k(expected, retrieved, 1) == 0.0
+    assert precision_at_k(expected, retrieved, 2) == 0.5
+    assert precision_at_k(expected, retrieved, 3) == 1 / 3
+
+
+def test_reciprocal_rank():
+    expected = {"mem_001"}
+    retrieved = ["mem_003", "mem_001", "mem_004"]
+
+    assert reciprocal_rank(expected, retrieved) == 0.5
+
+
+def test_reciprocal_rank_returns_zero_when_no_relevant_result():
+    expected = {"mem_999"}
+    retrieved = ["mem_003", "mem_001", "mem_004"]
+
+    assert reciprocal_rank(expected, retrieved) == 0.0
+
+
+def test_source_hit_at_k():
+    expected = {"mem_001"}
+    retrieved = ["mem_003", "mem_001", "mem_004"]
+
+    assert source_hit_at_k(expected, retrieved, 1) == 0
+    assert source_hit_at_k(expected, retrieved, 2) == 1
+
+
+def test_evaluate_single_query():
+    result = evaluate_single_query(
+        expected_ids=["mem_001"],
+        retrieved_ids=["mem_003", "mem_001", "mem_004"],
+        k_values=(1, 3),
+    )
+
+    assert result["recall@1"] == 0.0
+    assert result["precision@1"] == 0.0
+    assert result["source_hit@1"] == 0
+    assert result["recall@3"] == 1.0
+    assert result["precision@3"] == 1 / 3
+    assert result["source_hit@3"] == 1
+    assert result["mrr"] == 0.5
+
+
+def test_evaluate_retriever_with_mocked_rankings():
+    memories = [
+        {"memory_id": "mem_001", "content": "alpha"},
+        {"memory_id": "mem_002", "content": "beta"},
+    ]
+    queries = [
+        {
+            "query_id": "q_001",
+            "query": "alpha question",
+            "expected_memory_ids": ["mem_001"],
+        }
+    ]
+
+    def fake_retriever(query, memories, top_k):
+        return ["mem_002", "mem_001"]
+
+    report = evaluate_retriever(
+        memories=memories,
+        queries=queries,
+        retriever=fake_retriever,
+        top_k=2,
+        k_values=(1, 2),
+    )
+
+    assert report["num_queries"] == 1
+    assert report["aggregate_metrics"]["recall@1"] == 0.0
+    assert report["aggregate_metrics"]["recall@2"] == 1.0
+    assert report["aggregate_metrics"]["precision@2"] == 0.5
+    assert report["aggregate_metrics"]["mrr"] == 0.5
+
+
+def test_deterministic_keyword_retriever_returns_stable_order():
+    memories = [
+        {
+            "memory_id": "mem_b",
+            "content": "User likes machine learning and IoT.",
+            "metadata": {"entities": ["machine learning"]},
+        },
+        {
+            "memory_id": "mem_a",
+            "content": "User likes machine learning.",
+            "metadata": {"entities": ["machine learning"]},
+        },
+    ]
+
+    first_run = deterministic_keyword_retriever(
+        "machine learning interest",
+        memories,
+        top_k=2,
+    )
+    second_run = deterministic_keyword_retriever(
+        "machine learning interest",
+        memories,
+        top_k=2,
+    )
+
+    assert first_run == second_run
+
+
+def test_version_controlled_dataset_files_load():
+    base_path = Path(__file__).resolve().parents[1] / "app" / "evaluation" / "data"
+
+    memories = load_json(base_path / "synthetic_memories.json")
+    queries = load_json(base_path / "rag_eval_queries.json")
+
+    assert memories
+    assert queries
+    assert all("memory_id" in memory for memory in memories)
+    assert all("expected_memory_ids" in query for query in queries)
+
+
+def test_report_writers_create_json_and_csv(tmp_path):
+    report = {
+        "num_queries": 1,
+        "top_k": 2,
+        "aggregate_metrics": {
+            "recall@2": 1.0,
+            "precision@2": 0.5,
+            "mrr": 0.5,
+            "source_hit@2": 1.0,
+        },
+        "per_query": [
+            {
+                "query_id": "q_001",
+                "query": "sample query",
+                "expected_memory_ids": ["mem_001"],
+                "retrieved_memory_ids": ["mem_002", "mem_001"],
+                "metrics": {
+                    "recall@2": 1.0,
+                    "precision@2": 0.5,
+                    "mrr": 0.5,
+                    "source_hit@2": 1,
+                },
+            }
+        ],
+    }
+
+    json_path = tmp_path / "reports" / "benchmark.json"
+    csv_path = tmp_path / "reports" / "benchmark.csv"
+
+    save_json_report(report, json_path)
+    save_csv_report(report, csv_path)
+
+    assert json_path.exists()
+    assert csv_path.exists()
+    assert "sample query" in csv_path.read_text(encoding="utf-8")


### PR DESCRIPTION
# Description

This PR introduces an **offline retrieval evaluation benchmark** for Verath using a deterministic synthetic memory dataset and predefined query-to-memory mappings.

The primary goal of this contribution is to provide a lightweight framework for measuring retrieval quality over time without relying on external LLM providers, API keys, or real user data.

The benchmark focuses **exclusively on retrieval evaluation** and intentionally avoids answer-generation benchmarking to keep the scope small, maintainable, and aligned with the current architecture.

---

## Related Issue

Fixes #130

---

## What Changed

### Added a deterministic synthetic benchmark dataset

Introduced version-controlled synthetic memory records containing:

- Stable `memory_id` values
- Memory content representing different categories of information
- Associated metadata fields
- No dependency on real user data

Files added:

```text
backend/app/evaluation/data/synthetic_memories.json