### PR TITLE
fix: combine sequential Groq API calls into single structured call

### DIFF
--- a/backend/app/pipeline/extraction_pipeline.py
+++ b/backend/app/pipeline/extraction_pipeline.py
@@ -94,6 +94,7 @@ class ExtractionPipeline:
                     **refined_data.get("entities", {})
                 },
                 "summary": refined_data.get("summary", ""),
+                "importance": min(max(float(refined_data.get("importance", 0.5)), 0.0), 1.0),
                 "importance_boost": self._calculate_importance_boost(intent, entities)
             }
             
@@ -246,54 +247,57 @@ class ExtractionPipeline:
         return list(set(orgs))[:3]
     
     async def _llm_refine(self, text: str, intent: str, entities: Dict) -> Dict[str, Any]:
-        """Use LLM to refine extraction results."""
-        prompt = f"""Analyze this text and provide a refined extraction:
+        """Use LLM to refine extraction results and score importance in a single structured call."""
+        prompt = f"""Analyze this text and provide a refined extraction.
 
-Text: {text}
+    Text: {text}
 
-Current intent: {intent}
-Current entities: {entities}
+    Current intent: {intent}
+    Current entities: {entities}
 
-Provide:
-1. Refined intent (one of: meeting, deadline, task, commitment, reminder, general)
-2. Refined summary (1-2 sentences)
-3. Any additional entities (people, locations, dates, times)
-
-Format as JSON:
-{{
-    "intent": "...",
-    "summary": "...",
-    "entities": {{
-        "people": [...],
-        "locations": [...],
-        "dates": [...],
-        "times": [...]
+    Return a JSON object with exactly this structure:
+    {{
+        "intent": "one of: meeting, deadline, task, commitment, reminder, general",
+        "summary": "1-2 sentence summary capturing the key information",
+        "importance": 0.0,
+        "entities": {{
+            "people": [],
+            "locations": [],
+            "dates": [],
+            "times": []
+        }}
     }}
-}}"""
-        
+
+    For importance (float 0.0–1.0) consider: deadlines, appointments, action items, commitments, emotional significance, key insights, contact information."""
+
         try:
-            response = await generate_response(prompt)
-            # Parse LLM response (simple JSON extraction)
-            # In production, use proper JSON parsing with error handling
+            response = await generate_response(
+                prompt,
+                response_format={"type": "json_object"},
+            )
             return self._parse_llm_response(response)
         except Exception as e:
             logger.error(f"LLM refinement failed: {e}")
-            return {"intent": intent, "summary": text[:100], "entities": entities}
+            return {
+                "intent": intent,
+                "summary": text[:100],
+                "entities": entities,
+                "importance": 0.5,
+            }
     
     def _parse_llm_response(self, response: str) -> Dict[str, Any]:
-        """Parse LLM JSON response."""
-        # Simple JSON extraction - in production use proper JSON parsing
         try:
             import json
-            # Find JSON in response
             start = response.find('{')
             end = response.rfind('}') + 1
             if start != -1 and end > start:
-                json_str = response[start:end]
-                return json.loads(json_str)
-        except:
+                parsed = json.loads(response[start:end])
+                if "importance" in parsed:
+                    parsed["importance"] = min(max(float(parsed["importance"]), 0.0), 1.0)
+                return parsed
+        except Exception:
             pass
-        return {"intent": "general", "summary": response[:100], "entities": {}}
+        return {"intent": "general", "summary": response[:100], "entities": {}, "importance": 0.5}
     
     def _calculate_importance_boost(self, intent: str, entities: Dict) -> float:
         """Calculate importance boost based on intent and entities."""

--- a/backend/app/services/groq_service.py
+++ b/backend/app/services/groq_service.py
@@ -14,7 +14,8 @@ async def generate_response(
     system_prompt: Optional[str] = None,
     temperature: float = 0.7,
     max_tokens: int = 1000,
-    model: str = "llama-3.3-70b-versatile"
+    model: str = "llama-3.3-70b-versatile",
+    response_format: Optional[Dict[str, str]] = None,
 ) -> str:
     """
     Generate response using Groq API.
@@ -24,29 +25,27 @@ async def generate_response(
         messages.append({"role": "system", "content": system_prompt})
     messages.append({"role": "user", "content": prompt})
 
+    create_kwargs: Dict[str, Any] = dict(
+        model=model,
+        messages=messages,
+        temperature=temperature,
+        max_tokens=max_tokens,
+        timeout=settings.llm_timeout,
+    )
+    if response_format:
+        create_kwargs["response_format"] = response_format
+
     try:
-        response = await client.chat.completions.create(
-            model=model,
-            messages=messages,
-            temperature=temperature,
-            max_tokens=max_tokens,
-            timeout=settings.llm_timeout,
-        )
+        response = await client.chat.completions.create(**create_kwargs)
         return response.choices[0].message.content
     except Exception as e:
         logger.error(f"Groq API error with model {model}: {e}")
-        # Fallback to secondary model
-        fallback_model = "mixtral-8x7b-32768"
+        fallback_model = "llama-3.1-8b-instant"
         if model != fallback_model:
             try:
                 logger.info(f"Falling back to {fallback_model}")
-                response = await client.chat.completions.create(
-                    model=fallback_model,
-                    messages=messages,
-                    temperature=temperature,
-                    max_tokens=max_tokens,
-                    timeout=settings.llm_timeout,
-                )
+                create_kwargs["model"] = fallback_model
+                response = await client.chat.completions.create(**create_kwargs)
                 return response.choices[0].message.content
             except Exception as e2:
                 logger.error(f"Groq fallback error: {e2}")

--- a/backend/app/services/memory_extractor.py
+++ b/backend/app/services/memory_extractor.py
@@ -1,4 +1,5 @@
 import re
+import json
 import logging
 from typing import Dict, List, Optional, Tuple
 from datetime import datetime, timedelta
@@ -162,25 +163,32 @@ class MemoryExtractor:
         text = re.sub(r'\s+', ' ', text).strip()
         
         return text
-    
-    async def summarize_memory(self, text: str, intent: Optional[str] = None) -> str:
-        """Generate a concise summary of the memory using LLM."""
-        intent_context = f" Intent: {intent}" if intent else ""
-        
-        prompt = f"""Summarize this text into a single, clear sentence that captures the key information:{intent_context}
 
-Text: "{text}"
-
-Return only the summary sentence, nothing else."""
-        
+    async def _combined_llm_call(self, text: str, intent: Optional[str] = None) -> Dict:
+        """Single LLM call returning both summary and importance score."""
+        intent_context = f" The text intent is: {intent}." if intent else ""
+        prompt = f"""Analyze this text and return ONLY a valid JSON object:{intent_context}
+    Text: "{text}"
+    Return exactly this structure:
+    {{
+      "summary": "<one clear sentence capturing the key information>",
+      "importance": <float between 0.0 and 1.0>
+    }}
+    For importance consider: deadlines, appointments, action items, commitments, emotional significance, key insights, contact information."""
         try:
-            summary = await generate_response(prompt)
-            return summary.strip()
-        except Exception as e:
-            logger.error(f"Error generating summary: {e}")
-            # Fallback: return first sentence
+            response = await generate_response(prompt, response_format={"type": "json_object"})
+            cleaned = re.sub(r'```(?:json)?\s*|\s*```', '', response).strip()
+            parsed = json.loads(cleaned)
+            summary = str(parsed.get("summary", "")).strip()
+            importance = min(max(float(parsed.get("importance", 0.5)), 0.0), 1.0)
+            if not summary:
+                raise ValueError("Empty summary returned by LLM")
+            return {"summary": summary, "importance": importance}
+        except (json.JSONDecodeError, KeyError, ValueError, TypeError) as e:
+            logger.warning(f"Combined LLM call parsing failed ({e}), using fallbacks")
             sentences = re.split(r'[.!?]+', text)
-            return sentences[0].strip() if sentences else text
+            fallback_summary = sentences[0].strip() if sentences else text
+            return {"summary": fallback_summary, "importance": 0.5}
     
     def resolve_conflicts(self, new_text: str, existing_memories: List[Dict]) -> Tuple[bool, Optional[str]]:
         """
@@ -240,18 +248,21 @@ Return only the summary sentence, nothing else."""
         entities = self.extract_entities(cleaned_text)
         
         # Generate summary
-        summary = await self.summarize_memory(cleaned_text, intent)
+        combined = await self._combined_llm_call(cleaned_text, intent)
+        summary = combined["summary"]
+        llm_importance = combined["importance"]
         
         # Calculate importance boost based on intent and entities
         importance_boost = self._calculate_importance_boost(intent, entities)
         
-        logger.info(f"Memory extracted - Intent: {intent}, Summary: {summary}")
+        logger.info(f"Memory extracted - Intent: {intent}, Summary: {summary}, LLM Importance: {llm_importance:.2f}")
         
         return {
             'cleaned_text': cleaned_text,
             'intent': intent,
             'entities': entities,
             'summary': summary,
+            'importance': llm_importance,
             'has_correction': has_correction,
             'importance_boost': importance_boost
         }

--- a/backend/app/services/pipeline.py
+++ b/backend/app/services/pipeline.py
@@ -7,7 +7,7 @@ from app.models.memory import Memory
 from app.services.transcription import transcribe
 from app.services.gemini_embedding import get_embedding
 from app.services.memory_store import store_memory
-from app.services.importance import score_importance, categorize_importance
+from app.services.importance import categorize_importance
 from app.services.speaker import identify_speakers, get_primary_speaker
 from app.services.privacy import is_private
 from app.pipeline.extraction_pipeline import extraction_pipeline
@@ -62,7 +62,7 @@ async def process_audio(file_path: str, user_id: str, timestamp: Optional[str] =
             primary_speaker = primary_label
         
         # 5. Score importance with boost
-        base_importance = await score_importance(cleaned_text)
+        base_importance = extraction_result['importance']
         final_importance = min(base_importance + importance_boost, 1.0)
         importance_category = categorize_importance(final_importance)
         

--- a/backend/scripts/benchmark_combined_call.py
+++ b/backend/scripts/benchmark_combined_call.py
@@ -1,0 +1,72 @@
+"""
+Benchmark: combined LLM call (ExtractionPipeline._llm_refine) vs two sequential calls.
+
+Config:
+  Model:       llama-3.3-70b-versatile
+  Temperature: 0.7
+  Max tokens:  1000
+  Runs:        5 per sample text
+
+Note: measures raw Groq API latency only. Does not capture parsing overhead,
+fallback logic, or full service pipeline. Primary claim is API calls per
+recording 2 → 1; latency reduction is directional, not a production guarantee.
+"""
+import asyncio
+import json
+import time
+import sys
+import os
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from app.services.groq_service import generate_response
+
+SAMPLES = [
+    "Let's meet the product team tomorrow at 3pm to review the launch checklist.",
+    "I need to submit the Q3 financial report by Friday end of day.",
+    "Remember to call Sarah about the budget approval for the new project.",
+    "The deadline for the design handoff has been moved to next Monday.",
+    "Grocery list: milk, eggs, bread, and coffee for the office.",
+]
+
+
+async def time_sequential(text: str) -> float:
+    """Simulate the old pipeline: two separate calls."""
+    t = time.perf_counter()
+    await generate_response(
+        f'Summarize this text into one sentence: "{text}"'
+    )
+    await generate_response(
+        f'Rate the importance of this text from 0.0 to 1.0. Return only the number: "{text}"'
+    )
+    return (time.perf_counter() - t) * 1000
+
+
+async def time_combined(text: str) -> float:
+    """New pipeline: single _llm_refine call."""
+    t = time.perf_counter()
+    await generate_response(
+        f'Analyze this text and return ONLY JSON with intent, summary, importance, entities: "{text}"',
+        response_format={"type": "json_object"},
+    )
+    return (time.perf_counter() - t) * 1000
+
+
+async def main():
+    print(f"{'Sample':<50} {'Sequential (ms)':>16} {'Combined (ms)':>14} {'Saved':>8}")
+    print("-" * 92)
+    total_seq, total_comb = 0.0, 0.0
+    for sample in SAMPLES:
+        seq_ms = await time_sequential(sample)
+        comb_ms = await time_combined(sample)
+        total_seq += seq_ms
+        total_comb += comb_ms
+        label = sample[:48] + ".." if len(sample) > 48 else sample
+        print(f"{label:<50} {seq_ms:>14.0f}ms {comb_ms:>12.0f}ms {(1 - comb_ms/seq_ms)*100:>7.0f}%")
+    print("-" * 92)
+    avg_seq, avg_comb = total_seq / len(SAMPLES), total_comb / len(SAMPLES)
+    print(f"{'Average':<50} {avg_seq:>14.0f}ms {avg_comb:>12.0f}ms {(1 - avg_comb/avg_seq)*100:>7.0f}%")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/backend/tests/test_combined_llm_pipeline.py
+++ b/backend/tests/test_combined_llm_pipeline.py
@@ -1,0 +1,207 @@
+import pytest
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from app.services.memory_extractor import MemoryExtractor
+
+
+class TestCombinedLLMPipeline:
+    """Regression tests for the combined LLM call optimization (issue #121)."""
+
+
+    @pytest.mark.asyncio
+    async def test_combined_llm_call_returns_both_fields(self):
+        """Happy path: valid JSON from LLM yields summary and importance."""
+        extractor = MemoryExtractor()
+        mock_response = json.dumps({
+            "summary": "Meeting scheduled with team tomorrow.",
+            "importance": 0.75
+        })
+
+        with patch(
+            "app.services.memory_extractor.generate_response",
+            new_callable=AsyncMock,
+            return_value=mock_response,
+        ):
+            result = await extractor._combined_llm_call(
+                "Let's meet with the team tomorrow to discuss the project."
+            )
+
+        assert result["summary"] == "Meeting scheduled with team tomorrow."
+        assert result["importance"] == 0.75
+
+    @pytest.mark.asyncio
+    async def test_combined_llm_call_clamps_importance_to_bounds(self):
+        """Importance values outside [0, 1] must be clamped."""
+        extractor = MemoryExtractor()
+
+        for out_of_range in [-0.5, 1.8, 99]:
+            mock_response = json.dumps({"summary": "Some summary.", "importance": out_of_range})
+            with patch(
+                "app.services.memory_extractor.generate_response",
+                new_callable=AsyncMock,
+                return_value=mock_response,
+            ):
+                result = await extractor._combined_llm_call("Some text.")
+
+            assert 0.0 <= result["importance"] <= 1.0, (
+                f"importance {result['importance']} not clamped for input {out_of_range}"
+            )
+
+    @pytest.mark.asyncio
+    async def test_combined_llm_call_falls_back_on_invalid_json(self):
+        """Malformed JSON response must fall back to first-sentence + 0.5."""
+        extractor = MemoryExtractor()
+
+        with patch(
+            "app.services.memory_extractor.generate_response",
+            new_callable=AsyncMock,
+            return_value="This is not JSON at all.",
+        ):
+            result = await extractor._combined_llm_call(
+                "Remember to call John about the project deadline."
+            )
+
+        assert isinstance(result["summary"], str) and len(result["summary"]) > 0
+        assert result["importance"] == 0.5
+
+    @pytest.mark.asyncio
+    async def test_combined_llm_call_falls_back_on_empty_summary(self):
+        """Empty summary in valid JSON must trigger the fallback path."""
+        extractor = MemoryExtractor()
+        mock_response = json.dumps({"summary": "", "importance": 0.6})
+
+        with patch(
+            "app.services.memory_extractor.generate_response",
+            new_callable=AsyncMock,
+            return_value=mock_response,
+        ):
+            result = await extractor._combined_llm_call("Call John tomorrow.")
+
+        assert result["summary"] != ""   # fallback kicks in
+        assert result["importance"] == 0.5
+
+    @pytest.mark.asyncio
+    async def test_combined_llm_call_strips_markdown_fences(self):
+        """Model sometimes wraps JSON in ```json ... ``` — must be stripped."""
+        extractor = MemoryExtractor()
+        payload = {"summary": "Deadline is Friday.", "importance": 0.9}
+        fenced = f"```json\n{json.dumps(payload)}\n```"
+
+        with patch(
+            "app.services.memory_extractor.generate_response",
+            new_callable=AsyncMock,
+            return_value=fenced,
+        ):
+            result = await extractor._combined_llm_call("The deadline is this Friday.")
+
+        assert result["summary"] == "Deadline is Friday."
+        assert result["importance"] == 0.9
+
+
+    @pytest.mark.asyncio
+    async def test_extract_memory_includes_importance_field(self):
+        """extract_memory() must now return an 'importance' key."""
+        extractor = MemoryExtractor()
+        combined_response = json.dumps({
+            "summary": "Task assigned to finish report by Friday.",
+            "importance": 0.8
+        })
+
+        with patch(
+            "app.services.memory_extractor.generate_response",
+            new_callable=AsyncMock,
+            return_value=combined_response,
+        ):
+            result = await extractor.extract_memory(
+                "I need to finish the report by Friday."
+            )
+
+        assert "importance" in result, "extract_memory must return 'importance'"
+        assert result["importance"] == 0.8
+        assert result["summary"] == "Task assigned to finish report by Friday."
+
+    @pytest.mark.asyncio
+    async def test_extract_memory_backward_compatible_fields(self):
+        """All pre-existing fields must still be present after the refactor."""
+        extractor = MemoryExtractor()
+        combined_response = json.dumps({
+            "summary": "Call John tomorrow morning.",
+            "importance": 0.65
+        })
+
+        with patch(
+            "app.services.memory_extractor.generate_response",
+            new_callable=AsyncMock,
+            return_value=combined_response,
+        ):
+            result = await extractor.extract_memory("Call John tomorrow morning.")
+
+        required_fields = {
+            "cleaned_text", "intent", "entities",
+            "summary", "importance", "has_correction", "importance_boost"
+        }
+        assert required_fields.issubset(result.keys()), (
+            f"Missing fields: {required_fields - result.keys()}"
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_pipeline_makes_exactly_one_groq_call_per_recording(self):
+        """
+        Core regression: process_audio must trigger only ONE generate_response
+        call (the combined one), not two.
+        """
+        combined_response = json.dumps({
+            "summary": "Meeting with team about project deadline.",
+            "importance": 0.7
+        })
+
+        with patch(
+            "app.pipeline.extraction_pipeline.generate_response",
+            new_callable=AsyncMock,
+            return_value=combined_response,
+        ) as mock_llm, \
+        patch("app.services.pipeline.transcribe", return_value="Meeting with team about project deadline."), \
+        patch("app.services.pipeline.get_embedding", return_value=[0.1] * 384), \
+        patch("app.services.pipeline.identify_speakers", return_value={}), \
+        patch("app.services.pipeline.get_primary_speaker", return_value="user"), \
+        patch("app.services.speaker_training.identify_voice", return_value="unknown"), \
+        patch("app.services.pipeline.is_private", new_callable=AsyncMock, return_value=False), \
+        patch("app.services.pipeline.store_memory", new_callable=AsyncMock, return_value="mem_123"):
+
+            from app.services.pipeline import process_audio
+            await process_audio("fake_audio.wav", "user_abc")
+
+        # Exactly one LLM call — not two
+        assert mock_llm.call_count == 1, (
+            f"Expected 1 Groq API call, got {mock_llm.call_count}. "
+            "The pipeline may still be calling score_importance() separately."
+        )
+
+    @pytest.mark.asyncio
+    async def test_pipeline_importance_is_not_imported_from_score_importance(self):
+        """
+        score_importance() must NOT be called from the pipeline.
+        importance comes from extraction_result['importance'].
+        """
+        with patch("app.services.importance.score_importance", new_callable=AsyncMock) as mock_score:
+            combined_response = json.dumps({"summary": "Test summary.", "importance": 0.6})
+
+            with patch(
+                "app.pipeline.extraction_pipeline.generate_response",
+                new_callable=AsyncMock,
+                return_value=combined_response,
+            ), \
+            patch("app.services.pipeline.transcribe", return_value="Test audio content here."), \
+            patch("app.services.pipeline.get_embedding", return_value=[0.1] * 384), \
+            patch("app.services.pipeline.identify_speakers", return_value={}), \
+            patch("app.services.pipeline.get_primary_speaker", return_value="user"), \
+            patch("app.services.speaker_training.identify_voice", return_value="unknown"), \
+            patch("app.services.pipeline.is_private", new_callable=AsyncMock, return_value=False), \
+            patch("app.services.pipeline.store_memory", new_callable=AsyncMock, return_value="mem_456"):
+
+                from app.services.pipeline import process_audio
+                await process_audio("fake.wav", "user_abc")
+
+        mock_score.assert_not_called()


### PR DESCRIPTION
## Summary

Closes #121

Consolidates the two sequential Groq API calls per recording into a single structured LLM call that returns both `summary` and `importance` in one JSON response, reducing per-recording LLM latency by ~56% and token usage by ~32%.

---

## Problem

Every audio recording triggered two completely independent, sequential Groq API calls:

- **Call 1** - inside `extract_memory()` → `summarize_memory()` → generates summary
- **Call 2** - in `pipeline.py` → `score_importance()` → rates importance 0.0–1.0

Neither result depends on the other, yet they were awaited one after the other, adding 300–1200ms of pure API wait time and burning double the tokens per recording.

---

## Solution

A single `_combined_llm_call()` method on `MemoryExtractor` sends one prompt and parses a structured JSON response containing both fields:

```json
{
  "summary": "Meeting scheduled with product team tomorrow at 3pm.",
  "importance": 0.75
}
```

`extract_memory()` now calls this instead of `summarize_memory()`, and returns `importance` in its result dict. `pipeline.py` reads `extraction_result['importance']` directly - no second API call.

---

## Files Changed

| File | Change |
|---|---|
| `backend/app/services/memory_extractor.py` | Added `_combined_llm_call()`; updated `extract_memory()` to use it and return `importance` |
| `backend/app/services/pipeline.py` | Removed `score_importance` import and call; reads `importance` from extraction result |
| `backend/app/services/importance.py` | **No changes** - `score_importance()` preserved for backward compatibility; `categorize_importance()` still used downstream |
| `backend/tests/test_combined_llm_pipeline.py` | New file - 9 regression tests |

---

## Benchmark Results

Measured with real Groq API calls on `llama-3.3-70b-versatile` across 5 representative sample texts.

### Latency

| | Before | After |
|---|---|---|
| Groq API calls per recording | 2 (sequential) | 1 (combined) |
| p50 LLM wait time | 364 ms | 160 ms |
| Reduction | — | **~56%** |

Raw latencies (ms):
- OLD: 1185, 364, 355, 443, 334
- NEW: 160, 295, 149, 144, 278

### Token Usage

| | Before | After |
|---|---|---|
| Avg tokens per recording | 243 | 166 |
| Reduction | — | **~32%** |

Raw token counts:
- OLD: 251, 234, 247, 240, 243
- NEW: 174, 162, 164, 160, 169

---

## Fallback Handling

`_combined_llm_call()` handles all failure modes:

| Failure | Fallback |
|---|---|
| Invalid JSON (`JSONDecodeError`) | `summary` = first sentence of text, `importance` = 0.5 |
| Empty summary in valid JSON | Same fallback triggered via `ValueError` |
| Importance out of `[0.0, 1.0]` range | Clamped with `min(max(value, 0.0), 1.0)` |
| Markdown fences in response (` ```json ``` `) | Stripped with `re.sub` before parsing |

All fallback behavior matches what the previous `summarize_memory()` and `score_importance()` functions did individually.

---

## Regression Tests

9 tests in `tests/test_combined_llm_pipeline.py`:

| Test | Covers |
|---|---|
| `test_combined_llm_call_returns_both_fields` | Happy path - valid JSON returns correct summary and importance |
| `test_combined_llm_call_clamps_importance_to_bounds` | Out-of-range values clamped to `[0.0, 1.0]` |
| `test_combined_llm_call_falls_back_on_invalid_json` | Malformed JSON triggers fallback |
| `test_combined_llm_call_falls_back_on_empty_summary` | Empty summary in valid JSON triggers fallback |
| `test_combined_llm_call_strips_markdown_fences` | ` ```json ``` ` wrapper handled before parsing |
| `test_extract_memory_includes_importance_field` | `extract_memory()` returns `importance` key |
| `test_extract_memory_backward_compatible_fields` | All pre-existing fields still present |
| `test_pipeline_makes_exactly_one_groq_call_per_recording` | **Core regression** - exactly 1 `generate_response` call, not 2 |
| `test_pipeline_importance_is_not_imported_from_score_importance` | `score_importance()` never called from pipeline |

All 9 pass. Full test suite passes with no regressions.