### PR TITLE
fix(task-queue): add asyncio.Lock to prevent concurrent double-initialization race

### DIFF
--- a/backend/app/workers/task_queue.py
+++ b/backend/app/workers/task_queue.py
@@ -54,32 +54,42 @@ class TaskQueue:
     
     def __init__(self):
         self._initialized = False
+        self._init_lock = asyncio.Lock()
         self.worker_id = str(uuid.uuid4())
     
     async def _ensure_initialized(self):
-        """Ensure MongoDB connection and indexes are initialized."""
-        if self._initialized:
+        """Ensure MongoDB connection and indexes are initialized.
+
+        Uses an asyncio.Lock with a double-checked locking pattern to guarantee
+        that index creation runs exactly once even when multiple coroutines call
+        this method concurrently at startup.
+        """
+        if self._initialized:          # fast path — no lock needed after first init
             return
-        
-        db = get_db()
-        if db is None:
-            raise RuntimeError("Database not available for task queue")
-        
-        # Create indexes for efficient querying
-        try:
-            await db[self.COLLECTION_NAME].create_index([("task_id", 1)], unique=True)
-            await db[self.COLLECTION_NAME].create_index([("status", 1), ("next_retry_at", 1)])
-            await db[self.COLLECTION_NAME].create_index([("user_id", 1)])
-            await db[self.COLLECTION_NAME].create_index([("heartbeat_at", 1)])
-            await db[self.DEAD_LETTER_COLLECTION].create_index([("task_id", 1)], unique=True)
-            await db[self.DEAD_LETTER_COLLECTION].create_index([("user_id", 1)])
-            await db[self.DEAD_LETTER_COLLECTION].create_index([("failed_at", -1)])
-            
-            self._initialized = True
-            logger.info("Task queue initialized with indexes")
-        except Exception as e:
-            logger.error(f"Failed to initialize task queue indexes: {e}", exc_info=True)
-            raise
+
+        async with self._init_lock:
+            if self._initialized:      # re-check: another coroutine may have finished
+                return                 # while we were waiting for the lock
+
+            db = get_db()
+            if db is None:
+                raise RuntimeError("Database not available for task queue")
+
+            # Create indexes for efficient querying
+            try:
+                await db[self.COLLECTION_NAME].create_index([("task_id", 1)], unique=True)
+                await db[self.COLLECTION_NAME].create_index([("status", 1), ("next_retry_at", 1)])
+                await db[self.COLLECTION_NAME].create_index([("user_id", 1)])
+                await db[self.COLLECTION_NAME].create_index([("heartbeat_at", 1)])
+                await db[self.DEAD_LETTER_COLLECTION].create_index([("task_id", 1)], unique=True)
+                await db[self.DEAD_LETTER_COLLECTION].create_index([("user_id", 1)])
+                await db[self.DEAD_LETTER_COLLECTION].create_index([("failed_at", -1)])
+
+                self._initialized = True
+                logger.info("Task queue initialized with indexes")
+            except Exception as e:
+                logger.error(f"Failed to initialize task queue indexes: {e}", exc_info=True)
+                raise
     
     async def enqueue(self, task: Task) -> bool:
         """Enqueue a task for processing."""

--- a/backend/tests/test_task_queue_init_race.py
+++ b/backend/tests/test_task_queue_init_race.py
@@ -1,0 +1,139 @@
+"""
+Tests for TaskQueue._ensure_initialized concurrency safety.
+
+Verifies that concurrent coroutines calling _ensure_initialized() at startup
+result in index creation being executed exactly once per index, with no
+RuntimeError propagated to callers.
+"""
+import asyncio
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch, call
+
+
+@pytest.fixture
+def mock_db():
+    """Return a mock DB whose create_index records calls with a small delay."""
+    db = MagicMock()
+    collection = MagicMock()
+
+    async def slow_create_index(*args, **kwargs):
+        await asyncio.sleep(0)   # yield — forces cooperative interleaving
+        return "index_name"
+
+    collection.create_index = AsyncMock(side_effect=slow_create_index)
+    db.__getitem__ = MagicMock(return_value=collection)
+    return db, collection
+
+
+@pytest.fixture
+def task_queue_fresh():
+    """Return an uninitialised TaskQueue with no module-level side effects."""
+    from app.workers.task_queue import TaskQueue
+    return TaskQueue()
+
+
+class TestEnsureInitializedConcurrency:
+    """_ensure_initialized must be safe under concurrent async callers."""
+
+    async def test_create_index_called_once_per_index_under_concurrent_callers(
+        self, task_queue_fresh, mock_db
+    ):
+        """10 concurrent callers must trigger create_index exactly 7 times total."""
+        db, collection = mock_db
+
+        with patch("app.workers.task_queue.get_db", return_value=db):
+            await asyncio.gather(
+                *[task_queue_fresh._ensure_initialized() for _ in range(10)]
+            )
+
+        # 4 indexes on COLLECTION_NAME + 3 on DEAD_LETTER_COLLECTION = 7 total
+        assert collection.create_index.call_count == 7
+
+    async def test_initialized_flag_is_true_after_concurrent_callers(
+        self, task_queue_fresh, mock_db
+    ):
+        """_initialized must be True once all concurrent callers finish."""
+        db, _ = mock_db
+
+        with patch("app.workers.task_queue.get_db", return_value=db):
+            await asyncio.gather(
+                *[task_queue_fresh._ensure_initialized() for _ in range(10)]
+            )
+
+        assert task_queue_fresh._initialized is True
+
+    async def test_no_runtime_error_raised_under_concurrent_callers(
+        self, task_queue_fresh, mock_db
+    ):
+        """No RuntimeError must propagate from concurrent _ensure_initialized calls."""
+        db, _ = mock_db
+
+        with patch("app.workers.task_queue.get_db", return_value=db):
+            results = await asyncio.gather(
+                *[task_queue_fresh._ensure_initialized() for _ in range(10)],
+                return_exceptions=True,
+            )
+
+        errors = [r for r in results if isinstance(r, Exception)]
+        assert errors == [], f"Unexpected exceptions: {errors}"
+
+    async def test_second_call_is_noop_after_initialization(
+        self, task_queue_fresh, mock_db
+    ):
+        """Subsequent calls after successful init must not invoke create_index again."""
+        db, collection = mock_db
+
+        with patch("app.workers.task_queue.get_db", return_value=db):
+            await task_queue_fresh._ensure_initialized()
+            first_call_count = collection.create_index.call_count
+
+            await task_queue_fresh._ensure_initialized()
+            await task_queue_fresh._ensure_initialized()
+
+        assert collection.create_index.call_count == first_call_count
+
+    async def test_raises_runtime_error_when_db_unavailable(self, task_queue_fresh):
+        """RuntimeError must propagate when get_db() returns None."""
+        with patch("app.workers.task_queue.get_db", return_value=None):
+            with pytest.raises(RuntimeError, match="Database not available"):
+                await task_queue_fresh._ensure_initialized()
+
+    async def test_initialized_remains_false_on_index_creation_failure(
+        self, task_queue_fresh
+    ):
+        """_initialized must stay False if index creation raises — no silent half-init."""
+        db = MagicMock()
+        collection = MagicMock()
+        collection.create_index = AsyncMock(side_effect=Exception("mongo error"))
+        db.__getitem__ = MagicMock(return_value=collection)
+
+        with patch("app.workers.task_queue.get_db", return_value=db):
+            with pytest.raises(Exception, match="mongo error"):
+                await task_queue_fresh._ensure_initialized()
+
+        assert task_queue_fresh._initialized is False
+
+    async def test_enqueue_triggers_initialization_exactly_once(
+        self, task_queue_fresh, mock_db
+    ):
+        """Concurrent enqueue() calls at startup must initialise the queue only once."""
+        from app.workers.task_queue import Task, TaskType, TaskStatus
+        import uuid
+
+        db, collection = mock_db
+
+        # Make insert_one a no-op so enqueue() doesn't fail after init
+        collection.insert_one = AsyncMock(return_value=MagicMock())
+
+        def make_task():
+            return Task(
+                task_id=str(uuid.uuid4()),
+                task_type=TaskType.RECORDING,
+                payload={},
+                user_id="user-1",
+            )
+
+        with patch("app.workers.task_queue.get_db", return_value=db):
+            await asyncio.gather(*[task_queue_fresh.enqueue(make_task()) for _ in range(10)])
+
+        assert collection.create_index.call_count == 7


### PR DESCRIPTION
## Summary

Fixes #144.

## Root Cause

`_ensure_initialized` used a plain `bool` (`self._initialized`) as its only guard. Since Python's asyncio scheduler yields at every `await`, multiple coroutines could all read `self._initialized = False` before any of them completed index creation, then proceed to call `create_index` concurrently. The first coroutine to finish set `self._initialized = True` while siblings were still awaiting their own `create_index` calls — leaving the queue in a partially initialized state visible to subsequent callers.

## Fix

Two targeted changes in `backend/app/workers/task_queue.py`:

1. **`__init__`** — instantiate `self._init_lock = asyncio.Lock()`.
2. **`_ensure_initialized`** — wrap the initialization body with `async with self._init_lock` and add a second `if self._initialized: return` check *inside* the lock (standard async double-checked locking pattern).

```python
async def _ensure_initialized(self):
    if self._initialized:          # fast path — no lock overhead after first init
        return
    async with self._init_lock:
        if self._initialized:      # re-check: another coroutine may have finished
            return
        # ... index creation ...
        self._initialized = True
```

This guarantees:
- Only one coroutine executes the initialization body to completion.
- All other concurrent callers either exit on the outer fast-path or wait on the lock and exit on the inner re-check.
- `self._initialized` is never set `True` before all indexes are created.

## Tests added — `backend/tests/test_task_queue_init_race.py`

| Test | What it verifies |
|---|---|
| `test_create_index_called_once_per_index_under_concurrent_callers` | 10 concurrent callers → `create_index` called exactly 7 times total |
| `test_initialized_flag_is_true_after_concurrent_callers` | `_initialized` is `True` after gather |
| `test_no_runtime_error_raised_under_concurrent_callers` | No exceptions propagate |
| `test_second_call_is_noop_after_initialization` | Subsequent calls are no-ops |
| `test_raises_runtime_error_when_db_unavailable` | `RuntimeError` propagates when `get_db()` returns `None` |
| `test_initialized_remains_false_on_index_creation_failure` | `_initialized` stays `False` on partial failure |
| `test_enqueue_triggers_initialization_exactly_once` | `enqueue()` concurrent callers initialize once |

All mocks use `asyncio.sleep(0)` inside `create_index` to force cooperative interleaving and expose the race reliably.

## Scope

Changes are limited to `__init__` and `_ensure_initialized` only. No queue logic, retry behaviour, or DB access patterns are altered.

## Checklist
- [x] `asyncio.Lock` added to `__init__`
- [x] Double-checked locking pattern in `_ensure_initialized`
- [x] `_initialized = True` only set after all indexes are created
- [x] Concurrent startup tests covering 10+ simultaneous callers
- [x] No unrelated changes