### PR TITLE
fix: store server-normalized username in AsyncStorage on login

### DIFF
--- a/mobile/screens/LoginScreen.js
+++ b/mobile/screens/LoginScreen.js
@@ -36,7 +36,7 @@ export default function LoginScreen({ onLoginSuccess, onSwitchToRegister }) {
         if (response.data.refresh_token) {
           await AsyncStorage.setItem(REFRESH_KEY, response.data.refresh_token);
         }
-        await AsyncStorage.setItem(USERNAME_KEY, username);
+        await AsyncStorage.setItem(USERNAME_KEY, response.data.username);
         onLoginSuccess();
       } else {
         Alert.alert("Login Failed", "Invalid credentials");


### PR DESCRIPTION
## Description
The \LoginScreen\ was storing the raw user-input \username\ into AsyncStorage instead of the server-normalized value returned in the login response. The backend normalizes usernames with \.lower().strip()\, but the app discarded this normalized version, causing UI inconsistencies.

## Fix
Changed line 39 from:
\\\js
await AsyncStorage.setItem(USERNAME_KEY, username);
\\\
to:
\\\js
await AsyncStorage.setItem(USERNAME_KEY, response.data.username);
\\\

## Impact
- Fixes case-mismatch issues in profile lookups, leaderboard positions, and friend searches
- Eliminates user confusion from inconsistent username display

Closes #92