### PR TITLE
fix(auth): route /logout through get_current_user and handle duplicate blacklist insert (#154)

### DIFF
--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -1,5 +1,7 @@
 import logging
-from fastapi import APIRouter, HTTPException, status, Request
+from fastapi import APIRouter, HTTPException, status, Request, Depends
+from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
+from pymongo.errors import DuplicateKeyError
 from pydantic import BaseModel
 from slowapi import Limiter, _rate_limit_exceeded_handler
 from slowapi.util import get_remote_address
@@ -15,6 +17,7 @@ from app.services.auth import (
     create_refresh_token,
     verify_refresh_token,
     decode_access_token,
+    get_current_user,
     ALGORITHM,
     get_lockout_seconds_remaining,
     register_failed_login,
@@ -25,6 +28,8 @@ from app.services.database import get_db
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/auth", tags=["auth"])
+
+_bearer = HTTPBearer()
 
 # Rate limiting configuration
 limiter = Limiter(key_func=get_remote_address)
@@ -153,46 +158,48 @@ async def refresh(request: Request, body: RefreshRequest):
 
 
 @router.post("/logout")
-async def logout(request: Request):
+async def logout(
+    request: Request,
+    current_user: dict = Depends(get_current_user),
+    creds: HTTPAuthorizationCredentials = Depends(_bearer),
+):
     """
     Logout user and invalidate their access token.
     Stores the JWT ID (jti) in the blacklist collection.
+
+    Auth goes through get_current_user, which calls verify_access_token and
+    rejects already-blacklisted tokens (401) — consistent with every other
+    protected route, so a blacklisted token never reaches the insert below.
+    The DuplicateKeyError guard remains as defense-in-depth so a race or
+    repeat never surfaces as an unhandled 500.
     """
-    auth_header = request.headers.get("Authorization")
-    if not auth_header or not auth_header.startswith("Bearer "):
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="No authorization token provided"
-        )
-    
-    token = auth_header.split(" ")[1]
-    payload = decode_access_token(token)
-    
+    payload = decode_access_token(creds.credentials)
     if not payload:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Invalid token"
+            detail="Invalid token",
         )
-    
+
     jti = payload.get("jti")
     exp = payload.get("exp")
-    username = payload.get("sub")
+    username = current_user["username"]
     ip_address = request.client.host if request.client else "unknown"
-    
-    if jti and exp:
-        # Add to blacklist
-        db = get_db()
-        await db["blacklisted_tokens"].insert_one({
-            "jti": jti,
-            "exp": datetime.fromtimestamp(exp),
-            "blacklisted_at": datetime.utcnow(),
-            "username": username
-        })
-    
-    await _log_auth_event(username, ip_address, "logout", True)
-    
-    return {"message": "Logged out successfully"}
 
+    if jti and exp:
+        db = get_db()
+        try:
+            await db["blacklisted_tokens"].insert_one({
+                "jti": jti,
+                "exp": datetime.fromtimestamp(exp),
+                "blacklisted_at": datetime.utcnow(),
+                "username": username,
+            })
+        except DuplicateKeyError:
+            # Already blacklisted — treat repeat logout as success (idempotent).
+            pass
+
+    await _log_auth_event(username, ip_address, "logout", True)
+    return {"message": "Logged out successfully"}
 
 async def _log_auth_event(username: str, ip_address: str, event_type: str, success: bool):
     """Log authentication events to both file and MongoDB."""

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -253,3 +253,63 @@ class TestAuth:
         assert response.status_code == status.HTTP_200_OK
         assert len(inserted_docs) == 1
         assert inserted_docs[0].get("username") == "testuser"
+        
+    # ── Logout blacklist-bypass / crash tests  ──────────
+
+    async def test_logout_rejects_already_blacklisted_token(
+        self, client: AsyncClient, monkeypatch
+    ):
+        """A token whose jti is already blacklisted must be rejected at
+        /logout (401) rather than treated as valid — /logout must go through
+        the same blacklist check as every other protected route."""
+        token = create_access_token("testuser")
+
+        # blacklist lookup returns a hit → token is already revoked
+        mock_blacklist = AsyncMock(return_value={"jti": "blocked"})
+        fake_col = type(
+            "BlacklistCollection", (), {"find_one": mock_blacklist}
+        )()
+        fake_db = {"blacklisted_tokens": fake_col}
+        monkeypatch.setattr("app.services.auth.get_db", lambda: fake_db)
+
+        response = await client.post(
+            "/auth/logout",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    async def test_relogout_does_not_500_on_duplicate(
+        self, client: AsyncClient, monkeypatch
+    ):
+        """Re-submitting a token to /logout must not crash with HTTP 500 even
+        if the insert hits the unique-jti index (DuplicateKeyError handled)."""
+        from pymongo.errors import DuplicateKeyError
+
+        token = create_access_token("testuser")
+
+        # Not in blacklist on lookup (so auth passes), but insert raises a
+        # duplicate-key error (simulating a race / repeat).
+        mock_find = AsyncMock(return_value=None)
+        mock_insert = AsyncMock(side_effect=DuplicateKeyError("dup jti"))
+        fake_col = type(
+            "BlacklistCollection",
+            (),
+            {"find_one": mock_find, "insert_one": mock_insert},
+        )()
+        fake_db = {"blacklisted_tokens": fake_col}
+
+        # both the service-layer blacklist check and the route-layer insert
+        # resolve get_db to our fake
+        monkeypatch.setattr("app.services.auth.get_db", lambda: fake_db)
+        monkeypatch.setattr("app.routes.auth.get_db", lambda: fake_db)
+
+        response = await client.post(
+            "/auth/logout",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+        # Must NOT be a 500 — the DuplicateKeyError is caught and logout
+        # succeeds idempotently.
+        assert response.status_code != status.HTTP_500_INTERNAL_SERVER_ERROR
+        assert response.status_code == status.HTTP_200_OK


### PR DESCRIPTION
## Summary

Closes #154.

Fixes two compounding security bugs in the logout flow (both verified against current `main`):

**Bug 1 — `/logout` bypassed the blacklist check.** The endpoint parsed the `Authorization` header manually and called `decode_access_token()` (plain `jwt.decode`, no blacklist lookup) instead of the `get_current_user` dependency that every other protected route uses. `get_current_user` → `verify_access_token` checks `blacklisted_tokens`; `decode_access_token` does not. So an already-blacklisted token (from a previous logout or refresh rotation) was treated as valid at `/logout`.

**Bug 2 — re-submitting a blacklisted token returned HTTP 500.** `blacklisted_tokens.jti` has a unique index. A second logout with the same token reached `insert_one` and raised an uncaught `DuplicateKeyError` → unhandled 500. Anyone holding an old access token could repeatedly trigger this — a targeted DoS on the auth service.

## Changes

- `/logout` now depends on `get_current_user`, so it goes through `verify_access_token` and rejects blacklisted tokens (401) — consistent with every other protected route. A blacklisted token never reaches the insert.
- Kept the bearer credentials (via `HTTPBearer`) to extract `jti`/`exp` for blacklisting, since `get_current_user` returns only the username.
- Wrapped `insert_one` in `try/except DuplicateKeyError`, so a repeat/raced logout is idempotent (200) rather than a 500 — defense-in-depth even though Bug 1's fix already prevents a blacklisted token from reaching it.

I kept `datetime.fromtimestamp(exp)` as-is rather than changing it — the local-vs-UTC question is a separate concern and out of scope for this fix.

## Testing

Added two tests to `backend/tests/test_auth.py`:
- `test_logout_rejects_already_blacklisted_token` — a blacklisted token is rejected at `/logout` with 401 (fails on the old code, which returned 200 — the bypass proof).
- `test_relogout_does_not_500_on_duplicate` — when `insert_one` raises `DuplicateKeyError`, logout returns 200 instead of crashing.

Both pass, along with the existing logout/blacklist tests (7 passed, no regressions):

```text
tests/test_auth.py::TestAuth::test_logout_still_invalidates_access_token PASSED
tests/test_auth.py::TestAuth::test_logout_rejects_already_blacklisted_token PASSED
tests/test_auth.py::TestAuth::test_relogout_does_not_500_on_duplicate PASSED
... (7 passed, 7 deselected)
```

Note: the other tests in `test_auth.py` (signup/login/refresh) require a live MongoDB at `localhost:27017` and fail locally without one - this is pre-existing and unrelated to this change (those tests don't exercise `/logout`).