### PR TITLE
Add mobile auth validation

### DIFF
--- a/mobile/screens/LoginScreen.js
+++ b/mobile/screens/LoginScreen.js
@@ -8,6 +8,7 @@ import { LinearGradient } from "expo-linear-gradient";
 import { MaterialCommunityIcons } from "@expo/vector-icons";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { TOKEN_KEY, REFRESH_KEY, USERNAME_KEY } from "../services/authKeys";
+import { validateUsername, validatePassword } from "../services/validation";
 import axios from "axios";
 import { API_BASE_URL } from "../config";
 
@@ -21,14 +22,24 @@ export default function LoginScreen({ onLoginSuccess, onSwitchToRegister }) {
   const [focusedInput, setFocusedInput] = useState(null);
 
   const handleLogin = async () => {
-    if (!username || !password) {
-      Alert.alert("Error", "Please enter both username and password");
+    const trimmedUsername = username.trim();
+    const usernameError = validateUsername(trimmedUsername);
+    const passwordError = validatePassword(password);
+
+    if (usernameError) {
+      Alert.alert("Validation Error", usernameError);
       return;
     }
+
+    if (passwordError) {
+      Alert.alert("Validation Error", passwordError);
+      return;
+    }
+
     setLoading(true);
     try {
       const response = await axios.post(`${API_BASE}/auth/login`, {
-        username,
+        username: trimmedUsername,
         password,
       });
       if (response.data.access_token) {
@@ -36,7 +47,7 @@ export default function LoginScreen({ onLoginSuccess, onSwitchToRegister }) {
         if (response.data.refresh_token) {
           await AsyncStorage.setItem(REFRESH_KEY, response.data.refresh_token);
         }
-        await AsyncStorage.setItem(USERNAME_KEY, response.data.username);
+        await AsyncStorage.setItem(USERNAME_KEY, response.data.username || trimmedUsername);
         onLoginSuccess();
       } else {
         Alert.alert("Login Failed", "Invalid credentials");

--- a/mobile/screens/RegisterScreen.js
+++ b/mobile/screens/RegisterScreen.js
@@ -8,6 +8,7 @@ import { LinearGradient } from "expo-linear-gradient";
 import { MaterialCommunityIcons } from "@expo/vector-icons";
 import axios from "axios";
 import { API_BASE_URL } from "../config";
+import { validateUsername, validatePassword } from "../services/validation";
 
 const { width } = Dimensions.get("window");
 const API_BASE = API_BASE_URL;
@@ -20,14 +21,24 @@ export default function RegisterScreen({ onRegisterSuccess, onSwitchToLogin }) {
   const [focusedInput, setFocusedInput] = useState(null);
 
   const handleRegister = async () => {
-    if (!username || !password) {
-      Alert.alert("Error", "Please fill all fields");
+    const trimmedUsername = username.trim();
+    const usernameError = validateUsername(trimmedUsername);
+    const passwordError = validatePassword(password, { isSignup: true });
+
+    if (usernameError) {
+      Alert.alert("Validation Error", usernameError);
       return;
     }
+
+    if (passwordError) {
+      Alert.alert("Validation Error", passwordError);
+      return;
+    }
+
     setLoading(true);
     try {
       const response = await axios.post(`${API_BASE}/auth/signup`, {
-        username,
+        username: trimmedUsername,
         password,
       });
       if (response.status === 200 || response.status === 201) {

--- a/mobile/services/validation.js
+++ b/mobile/services/validation.js
@@ -1,0 +1,34 @@
+export const validateUsername = (username) => {
+  const trimmedUsername = username?.trim() || "";
+
+  if (!trimmedUsername) {
+    return "Username is required";
+  }
+
+  if (trimmedUsername.length < 3) {
+    return "Username must be at least 3 characters";
+  }
+
+  if (trimmedUsername.length > 50) {
+    return "Username must be 50 characters or less";
+  }
+
+  if (!/^[a-zA-Z0-9_-]+$/.test(trimmedUsername)) {
+    return "Username can only contain letters, numbers, underscores, and hyphens";
+  }
+
+  return null;
+};
+
+export const validatePassword = (password, { isSignup = false } = {}) => {
+  if (!password || password.trim() === "") {
+    return "Password is required";
+  }
+
+  if (isSignup && password.length < 8) {
+    return "Password must be at least 8 characters";
+  }
+
+  return null;
+};
+


### PR DESCRIPTION
## Summary

This PR adds client-side validation to the mobile login and register screens so the mobile auth flow matches the existing web/backend validation rules more closely.

## What Changed

- Trimmed username input before validation and submission.
- Blocked empty and whitespace-only usernames on-device.
- Added password validation for signup to reject passwords shorter than 8 characters.
- Replaced generic empty-field alerts with clearer validation messages.
- Kept the change focused to the mobile auth flow only.

## Files Updated

- `mobile/screens/LoginScreen.js`
- `mobile/screens/RegisterScreen.js`
- `mobile/services/validation.js`

## Why This Was Needed

The mobile app previously only checked whether fields were empty before making API requests. That allowed whitespace-only usernames and weak signup passwords to reach the backend, which created inconsistent behavior compared to the web auth form and added unnecessary requests.

## Acceptance Criteria

- Empty or whitespace-only usernames are blocked before the API request.
- Signup passwords under 8 characters are rejected on-device.
- Validation messages clearly explain what needs to be fixed.
- Login and register screens behave consistently with the existing web auth validation rules.

## Notes

- I kept the scope limited to mobile auth validation.
- No unrelated UI or styling changes were made.
- Contributed under GSSOC 2026.