### PR TITLE
feat: add session-level conversation history to AskScreen

### DIFF
--- a/backend/app/models/schema.py
+++ b/backend/app/models/schema.py
@@ -29,6 +29,19 @@ class MemoryResponse(BaseModel):
 
 
 # ── Query ─────────────────────────────────────────────────────────────────────
+class ConversationTurn(BaseModel):
+    role: str        # "user" or "assistant"
+    content: str
+
+
+class QueryRequest(BaseModel):
+    q: str = Field(..., min_length=1, max_length=500)
+    limit: int = Field(5, ge=1, le=20)
+    intent_filter: Optional[str] = None
+    min_importance: float = Field(0.0, ge=0.0, le=1.0)
+    history: List[ConversationTurn] = Field(default_factory=list)
+
+
 class SourceInfo(BaseModel):
     speaker: str = "unknown"
     intent: str = "general"

--- a/backend/app/routes/query.py
+++ b/backend/app/routes/query.py
@@ -1,7 +1,7 @@
 import logging
 from fastapi import APIRouter, Depends, HTTPException, Query
 from app.services.query_engine import run_query
-from app.models.schema import QueryResponse
+from app.models.schema import QueryResponse, QueryRequest
 from app.services.auth import get_current_user_id
 from app.core.logging_config import logger
 
@@ -49,6 +49,39 @@ async def query(
         "total_pages": total_pages
     }
 }
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Unexpected error in query: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail="Internal query error")
+
+_HISTORY_TURNS = 6
+
+
+@router.post("/query", response_model=QueryResponse)
+async def query_with_history(
+    body: QueryRequest,
+    user_id: str = Depends(get_current_user_id)
+):
+    """Query the memory system with optional session conversation history."""
+    try:
+        logger.info(f"Query from user {user_id}: {body.q[:50]}...")
+        result = await run_query(
+            user_id=user_id,
+            query=body.q,
+            limit=body.limit,
+            intent_filter=body.intent_filter,
+            min_importance=body.min_importance,
+            history=[{"role": t.role, "content": t.content} for t in body.history[-_HISTORY_TURNS:]],
+        )
+
+        logger.info(f"Query result sources count: {len(result.get('sources', []))}")
+
+        return {
+            **result,
+            "confidence": result.get("confidence_score", 0.0),
+            "sources": result.get("sources", []),
+        }
     except HTTPException:
         raise
     except Exception as e:

--- a/backend/app/services/query_engine.py
+++ b/backend/app/services/query_engine.py
@@ -20,6 +20,7 @@ async def run_query(
     limit: int = 5,
     intent_filter: Optional[str] = None,
     min_importance: float = 0.0,
+    history: Optional[List[Dict[str, str]]] = None,
 ) -> Dict[str, Any]:
     """
     Full RAG pipeline:
@@ -55,11 +56,20 @@ async def run_query(
         f"[Memory {i+1}]: {text}" for i, text in enumerate(context_texts)
     )
 
+    history_block = ""
+    if history:
+        turns = "\n".join(
+            f"{'User' if t['role'] == 'user' else 'Verath'}: {t['content']}"
+            for t in history
+        )
+        history_block = f"Recent conversation:\n{turns}\n\n"
+
     prompt = (
         f"You are a personal memory assistant. Answer the question using ONLY "
         f"the memories provided below. If the memories don't contain enough "
         f"information, say so honestly.\n\n"
         f"Memories:\n{context_block}\n\n"
+        f"{history_block}"
         f"Question: {query}\n\n"
         f"Answer:"
     )

--- a/backend/tests/test_query.py
+++ b/backend/tests/test_query.py
@@ -72,3 +72,61 @@ class TestQuery:
             headers=auth_headers
         )
         assert response.status_code == 200
+    
+    async def test_post_query_with_history_passes_turns_to_engine(
+        self, client: AsyncClient, monkeypatch, auth_headers
+    ):
+        """POST /query forwards history turns to run_query."""
+        captured = {}
+
+        async def mock_run_query(**kwargs):
+            captured.update(kwargs)
+            return {
+                "answer": "The first one is at 3 PM.",
+                "context": [],
+                "sources": [],
+                "confidence_score": 0.85,
+            }
+
+        monkeypatch.setattr("app.routes.query.run_query", mock_run_query)
+
+        response = await client.post(
+            "/query",
+            json={
+                "q": "What time is the first one?",
+                "history": [
+                    {"role": "user", "content": "What meetings do I have?"},
+                    {"role": "assistant", "content": "You have a meeting at 3 PM."},
+                ],
+            },
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["answer"] == "The first one is at 3 PM."
+        assert len(captured["history"]) == 2
+        assert captured["history"][0]["role"] == "user"
+
+    async def test_post_query_without_history_still_works(
+        self, client: AsyncClient, monkeypatch, auth_headers
+    ):
+        """POST /query with no history field is backward compatible."""
+        async def mock_run_query(**kwargs):
+            return {
+                "answer": "You have a meeting at 3 PM.",
+                "context": [],
+                "sources": [],
+                "confidence_score": 0.7,
+            }
+
+        monkeypatch.setattr("app.routes.query.run_query", mock_run_query)
+
+        response = await client.post(
+            "/query",
+            json={"q": "What meetings do I have?"},
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 200
+        assert "answer" in response.json()

--- a/mobile/screens/AskScreen.js
+++ b/mobile/screens/AskScreen.js
@@ -26,6 +26,8 @@ const SUGGESTIONS = [
   "What did I commit to this week?"
 ];
 
+const HISTORY_TURNS = 6;
+
 const Message = ({ text, isUser, sources, confidence }) => {
   return (
     <View style={[styles.messageRow, isUser && styles.messageRowUser]}>
@@ -77,13 +79,17 @@ export default function AskScreen({ navigation }) {
 
     const userQuery = query.trim();
     setQuery('');
-    
+
     setMessages(prev => [...prev, { id: Date.now(), text: userQuery, isUser: true }]);
     setLoading(true);
     scrollToBottom();
 
+    const history = messages
+      .slice(-HISTORY_TURNS)
+      .map(m => ({ role: m.isUser ? 'user' : 'assistant', content: m.text }));
+
     try {
-      const response = await askQuestion(userQuery);
+      const response = await askQuestion(userQuery, { history });
       setMessages(prev => [...prev, {
         id: Date.now() + 1,
         text: response.answer || "I couldn't find an answer to that question.",

--- a/mobile/services/api.js
+++ b/mobile/services/api.js
@@ -160,21 +160,26 @@ export const uploadAudio = async (uri) => {
 export const askQuestion = async (q, options = {}) => {
   try {
     const authHeader = await getAuthHeader();
-    const { limit = 5, intent_filter, speaker_filter } = options;
-    
-    let url = `${BASE_URL}/query?q=${encodeURIComponent(q)}&limit=${limit}`;
-    if (intent_filter) url += `&intent_filter=${intent_filter}`;
-    if (speaker_filter) url += `&speaker_filter=${speaker_filter}`;
-    
-    const response = await fetch(url, {
-      headers: { ...authHeader }
+    const { limit = 5, intent_filter, history = [] } = options;
+
+    const body = { q, limit };
+    if (intent_filter) body.intent_filter = intent_filter;
+    if (history.length > 0) body.history = history;
+
+    const response = await fetch(`${BASE_URL}/query`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...authHeader
+      },
+      body: JSON.stringify(body),
     });
-    
+
     if (!response.ok) {
       console.warn(`Query failed: ${response.status}`);
       return { answer: 'Verath encountered an error.', context: [], sources: [] };
     }
-    
+
     return await response.json();
   } catch (error) {
     console.error('Error asking question:', error);


### PR DESCRIPTION
## Summary

Fixes #122

AskScreen presents a full chat UI with message history but every query was fired as a standalone `GET /query?q=...` with no context passed to the backend. The LLMn prompt received only the current question, so follow-up questions like "What time is the first one?" or "Who is it with?" always failed there was no referent for pronouns anywhere in the prompt.

This PR adds a `POST /query` endpoint that accepts an optional `history` array and injects the last 6 conversation turns into the LLM prompt, enabling natural follow-up questions and pronoun resolution within a session.

---

## What changed

**Backend**
- `schema.py` - add `ConversationTurn` and `QueryRequest` Pydantic models
- `routes/query.py` - add `POST /query` endpoint; existing `GET /query` is untouched
- `query_engine.py` - add optional `history` parameter, inject turns into LLM prompt as a `Recent conversation:` block

**Frontend**
- `api.js` - switch `askQuestion()` from `GET` to `POST` with JSON body including `history`
- `AskScreen.js` - build last-6-turn history from `messages` state and pass on every submit

**Tests**
- `tests/test_query.py` - 2 new tests for `POST /query`: one verifying history is
forwarded to `run_query`, one verifying missing history doesn't break anything

---

## API contract

New endpoint:
```
POST /query
Body: {
  "q": "string",            (required)
  "limit": 5,               (optional)
  "intent_filter": "string" (optional)
  "min_importance": 0.0,    (optional)
  "history": [              (optional)
    { "role": "user",      "content": "What meetings do I have?" },
    { "role": "assistant", "content": "You have a meeting at 3 PM." }
  ]
}
Response: same shape as GET /query
```

`GET /query` is completely unchanged - backward compatible.

---

## Design decisions

- **Session-only** - history is passed per-request by the client. Nothing written to MongoDB or ChromaDB. No schema migrations.
- **Cap at 6 turns** - enforced in the route handler (`body.history[-6:]`) before passing to the engine. Keeps prompts lightweight.
- **Text injection, not native multi-turn** - history is injected as a `Recent conversation:` block in the prompt string rather than as separate Groq chat messages. Minimal blast radius - `groq_service.py` is untouched.
- **`GET /query` preserved** - existing integrations continue to work without changes.

---

## Before / After

| Before | After |
|--------|-------|
| ![before](https://github.com/user-attachments/assets/78e6d2dc-2827-46b5-955b-d30184b57650) | ![after](https://github.com/user-attachments/assets/5c5f7137-ff3a-419a-8007-39a703a79bb1) |
---

## Test results

```
platform win32 -- Python 3.13.13, pytest-8.1.1
asyncio: mode=Mode.AUTO

tests/test_query.py::TestQuery::test_query_returns_answer_sources_confidence PASSED        [ 16%]
tests/test_query.py::TestQuery::test_empty_memory_store_returns_graceful_response PASSED   [ 33%]
tests/test_query.py::TestQuery::test_intent_filter_param_correctly_filters_results PASSED  [ 50%]
tests/test_query.py::TestQuery::test_min_importance_param_correctly_filters_results PASSED [ 66%]
tests/test_query.py::TestQuery::test_post_query_with_history_passes_turns_to_engine PASSED [ 83%]
tests/test_query.py::TestQuery::test_post_query_without_history_still_works PASSED        [100%]

Name                          Stmts   Miss  Cover
--------------------------------------------------
app\models\schema.py             59      0   100%
app\routes\query.py              37     10    73%
app\services\query_engine.py     32     19    41%
--------------------------------------------------
6 passed in 6.50s
```

> Note: warnings in output are pre-existing (torchcodec DLL, Pydantic v1 config,
> `datetime.utcnow` deprecation) - none introduced by this PR.
```
