### PR TITLE
fix(ci): exclude test_e2e.py from default CI run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,10 @@ jobs:
     - name: Run tests
       run: |
         cd backend
-        pytest --cov=app --cov-report=xml
+        # test_e2e.py needs a live server on :8002 (see its docstring) and is
+        # run separately via `make e2e`; CI never starts that server, so it's
+        # excluded from the default suite here.
+        pytest --cov=app --cov-report=xml --ignore=tests/test_e2e.py
     
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v7


### PR DESCRIPTION
## Fixes #189

## Problem

`tests/test_e2e.py` is documented as manual-only in its own docstring (`Run with: python -m pytest tests/test_e2e.py -v`) and makes real HTTP calls to `http://localhost:8002`. CI's `test` job only starts the `mongodb` service container. it never starts the app itself yet `pytest.ini` sets `testpaths = tests`, so the default `pytest` run in CI discovers and executes `test_e2e.py` along with everything else.

Result: every CI run guarantees failures `test_1_signup` / `test_2_login` fail with `httpx.ConnectError` (no
server to connect to), and every test after that fails with `AttributeError: type object 'TestE2E' has no attribute 'access_token'`
(set only by the failing login test).

## Root cause

Not a test-logic bug, it's a CI/discovery gap. There's no step excluding this file from the automated run, even though the rest of the codebase already treats it as a separate, manual concern (see `Makefile`: `make test` vs `make e2e` are distinct targets; `make e2e` is the only one that runs `test_e2e.py`).

## Fix

One line, in the CI `Run tests` step only:

```diff
- pytest --cov=app --cov-report=xml
+ pytest --cov=app --cov-report=xml --ignore=tests/test_e2e.py
```

## Why exclude rather than start a live backend in CI

Two directions were on the table; I went with exclusion for these reasons:

- **Matches existing project convention.** `make test` / `make e2e` are already separate in the `Makefile`. This fix just makes the CI job's `pytest` invocation respect that same separation.
- **No new infrastructure or risk.** Booting `uvicorn` in CI would mean installing the full ML dependency stack (`torch`,
  `chromadb`, `pyannote.audio`, `sentence-transformers`) and coordinating it with the Mongo service just to satisfy 14 tests
  more moving parts, slower CI, more ways to be flaky.
- **Respects what the file already says about itself.** The docstring already states it's manual-only; this just stops CI from
  contradicting that.
- **Manual workflow is untouched.** The `--ignore` flag lives only in the CI command, not in `pytest.ini`, so `make e2e` and
  `python -m pytest tests/test_e2e.py -v` behave exactly as before.

## What this PR intentionally does not do

- Does not add a dedicated CI job/workflow to run `test_e2e.py` automatically against a live server (e.g. via `workflow_dispatch`). That's a separate feature (automated e2e coverage) with its own design questions (secrets, mocking external LLM calls, trigger conditions) and is left out to keep this PR scoped to #189.
- Does not modify `test_e2e.py` itself or any other test logic.
- Does not touch `pytest.ini`, fixtures, or `conftest.py`.

## Verification

**Before fix** - reproduces the bug exactly as described:
```
pytest tests/test_e2e.py -v
13 failed, 1 passed
```
(2x `ConnectError`, 11x `AttributeError` on `access_token`)

**After fix** - `test_e2e.py` contributes zero collected items; rest
of the suite runs unaffected:
```
pytest --cov=app --cov-report=xml --ignore=tests/test_e2e.py
```