### PR TITLE
fix: increment promoted_count/archived_count and fix silent-archival footgun in auto_promote_important_memories 

### DIFF
--- a/backend/app/db/memory_lifecycle.py
+++ b/backend/app/db/memory_lifecycle.py
@@ -146,24 +146,40 @@ class MemoryLifecycleManager:
             db = get_db()
             if db is None:
                 return
-            
+
             cursor = db.memories.find({
                 "user_id": user_id,
                 "lifecycle_stage": "short_term",
-                "metadata.importance": {"$gte": self.IMPORTANCE_THRESHOLD}   # was top-level "importance"
+                "metadata.importance": {"$gte": self.IMPORTANCE_THRESHOLD},
             })
-            
+
             promoted_count = 0
+            archived_count = 0
             async for mem in cursor:
-                importance = mem.get("metadata", {}).get("importance", 0.0)  
+                raw_importance = mem.get("metadata", {}).get("importance", None)
+                try:
+                    importance = float(raw_importance)
+                except (TypeError, ValueError):
+                    logger.warning(
+                        f"Memory {mem['_id']} matched DB filter but has non-numeric "
+                        f"metadata.importance={raw_importance!r}; skipping promotion."
+                    )
+                    continue
+
                 if importance >= self.IMPORTANCE_THRESHOLD:
-                    await self.promote_to_long_term(user_id, mem["_id"])
+                    promoted = await self.promote_to_long_term(user_id, mem["_id"])
+                    if promoted:
+                        promoted_count += 1
                 else:
-                    await self.archive_memory(user_id, mem["_id"])
-            
-            if promoted_count > 0:
-                logger.info(f"Auto-promoted {promoted_count} memories for user {user_id}")
-            
+                    archived = await self.archive_memory(user_id, mem["_id"])
+                    if archived:
+                        archived_count += 1
+
+            logger.info(
+                f"Auto-promotion complete for user {user_id}: "
+                f"promoted={promoted_count}, archived={archived_count}"
+            )
+
         except Exception as e:
             logger.error(f"Error auto-promoting memories: {e}", exc_info=True)
     

--- a/backend/tests/test_auto_promote_counter.py
+++ b/backend/tests/test_auto_promote_counter.py
@@ -1,0 +1,127 @@
+"""
+Tests for auto_promote_important_memories counter and observability fix.
+
+Verifies:
+  - promoted_count and archived_count are correctly incremented
+  - log line is always emitted (not gated on promoted_count > 0)
+  - type-mismatched importance values are warned and skipped (not silently archived)
+"""
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+def _make_db(docs):
+    """Return a mock db whose memories.find yields docs."""
+    async def _iter(*a, **kw):
+        for d in docs:
+            yield d
+
+    cursor = MagicMock()
+    cursor.__aiter__ = _iter
+    mock_col = MagicMock()
+    mock_col.find = MagicMock(return_value=cursor)
+    mock_col.update_one = AsyncMock(return_value=MagicMock(modified_count=1))
+    mock_db = MagicMock()
+    mock_db.memories = mock_col
+    return mock_db
+
+
+class TestAutoPromoteCounter:
+    async def test_promoted_count_incremented(self, monkeypatch, caplog):
+        """promoted_count must reflect the number of promote_to_long_term calls."""
+        docs = [
+            {"_id": "m1", "metadata": {"importance": 0.9}},
+            {"_id": "m2", "metadata": {"importance": 0.7}},
+        ]
+        mock_db = _make_db(docs)
+        monkeypatch.setattr("app.db.memory_lifecycle.get_db", lambda: mock_db)
+
+        from app.db.memory_lifecycle import MemoryLifecycleManager
+        mgr = MemoryLifecycleManager()
+
+        import logging
+        with caplog.at_level(logging.INFO, logger="app.db.memory_lifecycle"):
+            await mgr.auto_promote_important_memories("u1")
+
+        assert "promoted=2" in caplog.text
+        assert "archived=0" in caplog.text
+
+    async def test_archived_count_incremented(self, monkeypatch, caplog):
+        """archived_count must reflect memories that fail the Python-side re-check."""
+        # The DB filter already guarantees importance >= 0.6, but we test the
+        # archived branch by crafting a doc that slips through the DB mock with
+        # a low importance value (simulates a DB mock returning extra docs).
+        docs = [
+            {"_id": "m3", "metadata": {"importance": 0.3}},
+        ]
+        mock_db = _make_db(docs)
+        monkeypatch.setattr("app.db.memory_lifecycle.get_db", lambda: mock_db)
+
+        from app.db.memory_lifecycle import MemoryLifecycleManager
+        mgr = MemoryLifecycleManager()
+
+        import logging
+        with caplog.at_level(logging.INFO, logger="app.db.memory_lifecycle"):
+            await mgr.auto_promote_important_memories("u1")
+
+        assert "archived=1" in caplog.text
+        assert "promoted=0" in caplog.text
+
+    async def test_log_always_emitted_when_zero_promotions(self, monkeypatch, caplog):
+        """Log line must be emitted even when no memories are promoted."""
+        mock_db = _make_db([])
+        monkeypatch.setattr("app.db.memory_lifecycle.get_db", lambda: mock_db)
+
+        from app.db.memory_lifecycle import MemoryLifecycleManager
+        mgr = MemoryLifecycleManager()
+
+        import logging
+        with caplog.at_level(logging.INFO, logger="app.db.memory_lifecycle"):
+            await mgr.auto_promote_important_memories("u1")
+
+        assert "Auto-promotion complete" in caplog.text
+
+    async def test_type_mismatch_importance_warns_and_skips(self, monkeypatch, caplog):
+        """Non-numeric metadata.importance must emit a warning and skip the doc
+        without archiving it (no silent data loss)."""
+        docs = [
+            {"_id": "m4", "metadata": {"importance": "high"}},   # string, not float
+        ]
+        mock_db = _make_db(docs)
+        monkeypatch.setattr("app.db.memory_lifecycle.get_db", lambda: mock_db)
+
+        from app.db.memory_lifecycle import MemoryLifecycleManager
+        mgr = MemoryLifecycleManager()
+
+        import logging
+        with caplog.at_level(logging.WARNING, logger="app.db.memory_lifecycle"):
+            await mgr.auto_promote_important_memories("u1")
+
+        # Warning must be emitted
+        assert "non-numeric" in caplog.text
+        # update_one must NOT have been called (no silent archive)
+        mock_db.memories.update_one.assert_not_called()
+
+    async def test_mixed_batch_counts_correctly(self, monkeypatch, caplog):
+        """Mixed batch: 2 promoted, 1 archived, 1 type-mismatch skipped."""
+        docs = [
+            {"_id": "m5", "metadata": {"importance": 0.8}},   # promote
+            {"_id": "m6", "metadata": {"importance": 0.65}},  # promote
+            {"_id": "m7", "metadata": {"importance": 0.2}},   # archive
+            {"_id": "m8", "metadata": {"importance": None}},  # skip (warn)
+        ]
+        mock_db = _make_db(docs)
+        monkeypatch.setattr("app.db.memory_lifecycle.get_db", lambda: mock_db)
+
+        from app.db.memory_lifecycle import MemoryLifecycleManager
+        mgr = MemoryLifecycleManager()
+
+        import logging
+        with caplog.at_level(logging.WARNING, logger="app.db.memory_lifecycle"):
+            await mgr.auto_promote_important_memories("u1")
+
+        assert "promoted=2" in caplog.text
+        assert "archived=1" in caplog.text
+        assert "non-numeric" in caplog.text
+        # update_one called for m5 + m6 (promote) + m7 (archive) = 3 times
+        assert mock_db.memories.update_one.call_count == 3


### PR DESCRIPTION
## Summary

Fixes #143.

`auto_promote_important_memories` initialised `promoted_count = 0` but never incremented it, so the guarded log line `if promoted_count > 0: logger.info(...)` was permanently dead code. Operators had no visibility into background lifecycle promotion activity.

A secondary bug was also present: any document that matched the MongoDB `$gte` filter but held a non-numeric `metadata.importance` value (e.g. `"high"` stored as a string) would return `0.0` from `.get()`, fail the Python-side re-check, and be **silently archived** — data loss with no
log trail.

---

## Changes

**`backend/app/db/memory_lifecycle.py`**

| Before | After |
|--------|-------|
| `promoted_count` initialised but never incremented | `promoted_count` and `archived_count` incremented in their respective branches using the `bool` return of `promote_to_long_term` / `archive_memory` |
| `if promoted_count > 0: logger.info(...)` — always skipped | `logger.info(...)` always emitted with both counts |
| Non-numeric `metadata.importance` silently archived | `float()` cast with `try/except`; emits `logger.warning` and skips the doc (`continue`) — no silent data loss |

---

## Verification against current main

Per the maintainer's request in the issue thread:

- **MongoDB query** — `metadata.importance: {$gte: 0.6}` with `lifecycle_stage: "short_term"` (unchanged).
- **Lifecycle state field** — `lifecycle_stage` (top-level), consistent with `promote_to_long_term`, `archive_memory`, and the existing schema tests in `test_lifecycle_schema.py`.
- **Python-side re-check necessity** — the DB filter already guarantees `>= 0.6` for well-typed documents; the re-check is kept only as a type-safety guard that now warns instead of silently archiving.
- **Counter placement** — `promoted_count += 1` inside the `if importance >= IMPORTANCE_THRESHOLD` branch; `archived_count += 1` inside the `else` branch.

---

## Tests (`backend/tests/test_auto_promote_counter.py`)

| Test | Asserts |
|------|---------|
| `test_promoted_count_incremented` | `promoted=2, archived=0` in log for 2 high-importance docs |
| `test_archived_count_incremented` | `archived=1, promoted=0` in log for 1 low-importance doc |
| `test_log_always_emitted_when_zero_promotions` | `"Auto-promotion complete"` present even with empty cursor |
| `test_type_mismatch_importance_warns_and_skips` | `"non-numeric"` warning; `update_one` never called |
| `test_mixed_batch_counts_correctly` | 2 promoted + 1 archived + 1 skipped; `update_one` called exactly 3 times |