### PR TITLE
fix(auth): fail-closed token blacklist — deny revoked tokens when DB is unavailable

### DIFF
--- a/backend/app/services/auth.py
+++ b/backend/app/services/auth.py
@@ -53,7 +53,13 @@ def create_refresh_token(username: str) -> str:
 
 # ── Token verification ────────────────────────────────────────────────────────
 async def verify_access_token(token: str) -> Optional[str]:
-    """Returns username if valid access token, else None."""
+    """Returns username if valid access token, else None.
+
+    Fails closed: if the database is unavailable (get_db() returns None)
+    or the blacklist lookup raises, the token is rejected rather than
+    silently accepted. This prevents revoked tokens from being replayed
+    during periods of DB degradation.
+    """
     try:
         payload = jwt.decode(token, settings.secret_key, algorithms=[ALGORITHM])
         if payload.get("type") != "access":
@@ -61,10 +67,22 @@ async def verify_access_token(token: str) -> Optional[str]:
         jti = payload.get("jti")
         if jti:
             db = get_db()
-            if db is not None:
+            if db is None:
+                logger.warning(
+                    "verify_access_token: database unavailable — rejecting token "
+                    "(fail-closed); jti=%s", jti
+                )
+                return None
+            try:
                 blacklisted = await db["blacklisted_tokens"].find_one({"jti": jti})
-                if blacklisted:
-                    return None
+            except Exception:
+                logger.exception(
+                    "verify_access_token: blacklist lookup failed — rejecting token "
+                    "(fail-closed); jti=%s", jti
+                )
+                return None
+            if blacklisted:
+                return None
         return payload.get("sub")
     except JWTError:
         return None
@@ -75,6 +93,10 @@ async def verify_refresh_token(token: str) -> Optional[str]:
 
     Also checks the blacklisted_tokens collection so that rotated (or
     explicitly revoked) refresh tokens cannot be reused.
+
+    Fails closed: if the database is unavailable (get_db() returns None)
+    or the blacklist lookup raises, the token is rejected rather than
+    silently accepted.
     """
     try:
         payload = jwt.decode(token, settings.secret_key, algorithms=[ALGORITHM])
@@ -83,10 +105,22 @@ async def verify_refresh_token(token: str) -> Optional[str]:
         jti = payload.get("jti")
         if jti:
             db = get_db()
-            if db is not None:
+            if db is None:
+                logger.warning(
+                    "verify_refresh_token: database unavailable — rejecting token "
+                    "(fail-closed); jti=%s", jti
+                )
+                return None
+            try:
                 blacklisted = await db["blacklisted_tokens"].find_one({"jti": jti})
-                if blacklisted:
-                    return None
+            except Exception:
+                logger.exception(
+                    "verify_refresh_token: blacklist lookup failed — rejecting token "
+                    "(fail-closed); jti=%s", jti
+                )
+                return None
+            if blacklisted:
+                return None
         return payload.get("sub")
     except JWTError:
         return None

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -313,3 +313,115 @@ class TestAuth:
         # succeeds idempotently.
         assert response.status_code != status.HTTP_500_INTERNAL_SERVER_ERROR
         assert response.status_code == status.HTTP_200_OK
+
+    async def test_verify_access_token_rejects_when_db_unavailable(self, monkeypatch):
+        """
+        Security: verify_access_token must return None (fail-closed) when
+        get_db() returns None — not silently accept the token.
+        Regression for issue #142.
+        """
+        token = create_access_token("testuser")
+        monkeypatch.setattr("app.services.auth.get_db", lambda: None)
+
+        result = await verify_access_token(token)
+
+        assert result is None, (
+            "verify_access_token must deny tokens when DB is unavailable "
+            "(fail-closed), not accept them"
+        )
+
+    async def test_verify_refresh_token_rejects_when_db_unavailable(self, monkeypatch):
+        """
+        Security: verify_refresh_token must return None (fail-closed) when
+        get_db() returns None — not silently accept the token.
+        Regression for issue #142.
+        """
+        token = create_refresh_token("testuser")
+        monkeypatch.setattr("app.services.auth.get_db", lambda: None)
+
+        result = await verify_refresh_token(token)
+
+        assert result is None, (
+            "verify_refresh_token must deny tokens when DB is unavailable "
+            "(fail-closed), not accept them"
+        )
+
+    async def test_verify_access_token_rejects_when_blacklist_lookup_raises(self, monkeypatch):
+        """
+        Security: verify_access_token must return None if the blacklist
+        find_one raises (e.g. connection pool exhaustion, network partition).
+        Regression for issue #142.
+        """
+        token = create_access_token("testuser")
+
+        mock_col = MagicMock()
+        mock_col.find_one = AsyncMock(side_effect=Exception("connection reset"))
+        monkeypatch.setattr(
+            "app.services.auth.get_db",
+            lambda: {"blacklisted_tokens": mock_col},
+        )
+
+        result = await verify_access_token(token)
+
+        assert result is None
+
+    async def test_verify_refresh_token_rejects_when_blacklist_lookup_raises(self, monkeypatch):
+        """
+        Security: verify_refresh_token must return None if the blacklist
+        find_one raises (e.g. connection pool exhaustion, network partition).
+        Regression for issue #142.
+        """
+        token = create_refresh_token("testuser")
+
+        mock_col = MagicMock()
+        mock_col.find_one = AsyncMock(side_effect=Exception("connection reset"))
+        monkeypatch.setattr(
+            "app.services.auth.get_db",
+            lambda: {"blacklisted_tokens": mock_col},
+        )
+
+        result = await verify_refresh_token(token)
+
+        assert result is None
+
+    async def test_blacklisted_jti_rejected_even_after_db_recovers(self, monkeypatch):
+        """
+        Security: a token whose JTI was blacklisted before a DB outage must
+        remain rejected once the DB is back — the fail-closed path during
+        outage must not have 'cleared' the blacklist entry.
+        Regression for issue #142.
+        """
+        token = create_access_token("testuser")
+
+        # Phase 1: DB down — token must be rejected (fail-closed)
+        monkeypatch.setattr("app.services.auth.get_db", lambda: None)
+        result_during_outage = await verify_access_token(token)
+        assert result_during_outage is None
+
+        # Phase 2: DB back up with the JTI blacklisted — still rejected
+        mock_col = MagicMock()
+        mock_col.find_one = AsyncMock(return_value={"jti": "some-jti"})
+        monkeypatch.setattr(
+            "app.services.auth.get_db",
+            lambda: {"blacklisted_tokens": mock_col},
+        )
+        result_after_recovery = await verify_access_token(token)
+        assert result_after_recovery is None
+
+    async def test_valid_token_accepted_when_db_available_and_not_blacklisted(self, monkeypatch):
+        """
+        Sanity: fail-closed changes must not break the normal happy path —
+        a non-blacklisted token with DB available must still be accepted.
+        """
+        token = create_access_token("testuser")
+
+        mock_col = MagicMock()
+        mock_col.find_one = AsyncMock(return_value=None)  # not blacklisted
+        monkeypatch.setattr(
+            "app.services.auth.get_db",
+            lambda: {"blacklisted_tokens": mock_col},
+        )
+
+        result = await verify_access_token(token)
+
+        assert result == "testuser"


### PR DESCRIPTION
## Summary

Closes #142

`verify_access_token` and `verify_refresh_token` both contained an `if db is not None` guard around the blacklist lookup. The intent was to handle cold-start ordering, but the same guard fires during *runtime* DB unavailability, silently skipping the revocation check and accepting any structurally valid JWT — including tokens invalidated by logout or refresh rotation.

## Root Cause

```python
# Before — fail-open
db = get_db()
if db is not None:                              # silent bypass on DB down
    blacklisted = await db["blacklisted_tokens"].find_one({"jti": jti})
    if blacklisted:
        return None
return payload.get("sub")                       # revoked token accepted
```

## Fix

Replace the fail-open guard with a fail-closed pattern in both functions:

1. **`get_db()` returns `None`** → log a `WARNING` (with `jti`) and return `None` immediately. Token denied.
2. **`find_one` raises** (pool exhaustion, network partition, etc.) → log an `ERROR` and return `None`. Token denied.
3. **DB available and JTI not blacklisted** → return username as before (no regression to happy path).

```python
# After — fail-closed
db = get_db()
if db is None:
    logger.warning("database unavailable — rejecting token (fail-closed); jti=%s", jti)
    return None
try:
    blacklisted = await db["blacklisted_tokens"].find_one({"jti": jti})
except Exception:
    logger.exception("blacklist lookup failed — rejecting token (fail-closed); jti=%s", jti)
    return None
if blacklisted:
    return None
```

No changes to startup lifecycle, `create_indexes`, connection pooling, or any other auth logic.

## Tests Added

| Test | Covers |
|---|---|
| `test_verify_access_token_rejects_when_db_unavailable` | `get_db()` → `None` on access token |
| `test_verify_refresh_token_rejects_when_db_unavailable` | `get_db()` → `None` on refresh token |
| `test_verify_access_token_rejects_when_blacklist_lookup_raises` | `find_one` exception on access token |
| `test_verify_refresh_token_rejects_when_blacklist_lookup_raises` | `find_one` exception on refresh token |
| `test_blacklisted_jti_rejected_even_after_db_recovers` | Outage then recovery — JTI still rejected |
| `test_valid_token_accepted_when_db_available_and_not_blacklisted` | Happy path not broken |

## Scope

Per the assignment, changes are confined to:
- `backend/app/services/auth.py` — `verify_access_token()`, `verify_refresh_token()`
- `backend/tests/test_auth.py` — new tests for the above

## Security Impact

Before this fix, any period of MongoDB degradation (cold start, pool exhaustion, restart, partition) allowed an attacker holding a logged-out or rotated JWT to replay it indefinitely. This fix ensures the revocation model holds regardless of DB availability.