### PR TITLE
fix(tests): fix 4 bugs in test_system.py - nodes field, signup 201, None crash, false success message

### DIFF
--- a/backend/test_system.py
+++ b/backend/test_system.py
@@ -27,7 +27,8 @@ def test_status():
         response = requests.get(f"{BASE_URL}/status")
         if response.status_code == 200:
             data = response.json()
-            print_result(True, f"System is {data.get('status')} with {data.get('nodes')} nodes")
+            # FIX 1: replaced non-existent 'nodes' field with actual response fields
+            print_result(True, f"System is {data.get('status')}, version {data.get('version')}, scheduler {data.get('scheduler')}")
             return True
         else:
             print_result(False, f"Status code: {response.status_code}")
@@ -45,7 +46,8 @@ def test_signup():
             f"{BASE_URL}/auth/signup",
             json={"username": username, "password": "testpass123"}
         )
-        if response.status_code == 200:
+        # FIX 2: /auth/signup returns 201 Created, not 200
+        if response.status_code in (200, 201):
             data = response.json()
             print_result(True, f"User created: {username}")
             return username
@@ -86,7 +88,9 @@ def test_query(token):
         )
         if response.status_code == 200:
             data = response.json()
-            print_result(True, f"Query returned: {data.get('answer')[:50]}...")
+            # FIX 3: guard against None answer crashing with TypeError on [:50]
+            answer = data.get('answer') or ""
+            print_result(True, f"Query returned: {answer[:50]}...")
             return True
         else:
             print_result(False, f"Status code: {response.status_code}, Error: {response.text}")
@@ -162,7 +166,9 @@ def test_summary(token):
         )
         if response.status_code == 200:
             data = response.json()
-            print_result(True, f"Summary generated: {data.get('summary')[:50]}...")
+            # same None-guard as test_query for consistency
+            summary = data.get('summary') or ""
+            print_result(True, f"Summary generated: {summary[:50]}...")
             return True
         else:
             print_result(False, f"Status code: {response.status_code}, Error: {response.text}")
@@ -272,34 +278,43 @@ def main():
         print("\n❌ Login failed. Cannot continue with authenticated tests.")
         return
 
+    # FIX 4: track all results instead of unconditionally printing success
+    results = []
+
     # Test 4: Query
-    test_query(token)
+    results.append(test_query(token))
 
     # Test 5: Statistics
-    test_statistics(token)
+    results.append(test_statistics(token))
 
     # Test 6: Timeline
-    test_timeline(token)
+    results.append(test_timeline(token))
 
     # Test 7: Insights
-    test_insights(token)
+    results.append(test_insights(token))
 
     # Test 8: Summary
-    test_summary(token)
+    results.append(test_summary(token))
 
     # Test 9: Speaker auth regression
-    test_speaker_train_unauthenticated()
-    test_speaker_profiles_unauthenticated()
+    results.append(test_speaker_train_unauthenticated())
+    results.append(test_speaker_profiles_unauthenticated())
 
     # Test 10: Speaker authenticated
-    test_speaker_train_authenticated(token)
-    test_speaker_profiles_authenticated(token)
+    results.append(test_speaker_train_authenticated(token))
+    results.append(test_speaker_profiles_authenticated(token))
 
     # Final summary
     print("\n" + "="*60)
     print("Test Suite Complete")
     print("="*60)
-    print("\n✅ All basic endpoints are functional!")
+
+    failed = results.count(False)
+    if failed == 0:
+        print("\n✅ All basic endpoints are functional!")
+    else:
+        print(f"\n⚠️  {failed} test(s) failed. Check output above.")
+
     print("\nNext steps:")
     print("1. Test mobile app connection")
     print("2. Test web dashboard connection")


### PR DESCRIPTION
I have found more issues linked with the open issue, to avoid any conflicts i have applied the following changes,

Fixes #191

## Changes

### Fix 1 — `test_status()`: replaced non-existent `nodes` field (Issue #191)
`data.get('nodes')` always returned `None` since the `/status` endpoint
returns `status`, `version`, and `scheduler` — not `nodes`.

**Before:**
```python
print_result(True, f"System is {data.get('status')} with {data.get('nodes')} nodes")
```
**After:**
```python
print_result(True, f"System is {data.get('status')}, version {data.get('version')}, scheduler {data.get('scheduler')}")
```

---

### Fix 2 — `test_signup()`: accept HTTP 201 from `/auth/signup`
The API returns `201 Created` on successful signup (as documented in README),
but the test only accepted `200`. This caused the entire test suite to abort
on a fully working backend since `username` returned `None` and the early-exit
guard triggered.

**Before:**
```python
if response.status_code == 200:
```
**After:**
```python
if response.status_code in (200, 201):
```

---

### Fix 3 — `test_query()` and `test_summary()`: guard against `None` crash on `[:50]` slice
When a new user has zero memories, the backend returns `{"answer": null}`.
`data.get('answer')[:50]` raises `TypeError: 'NoneType' object is not subscriptable`,
crashing the test instead of reporting a clean result. Same bug existed in
`test_summary()` with the `summary` field — fixed both.

**Before:**
```python
print_result(True, f"Query returned: {data.get('answer')[:50]}...")
```
**After:**
```python
answer = data.get('answer') or ""
print_result(True, f"Query returned: {answer[:50]}...")
```

---

### Fix 4 — `main()`: track test results, don't unconditionally print success
The final `"✅ All basic endpoints are functional!"` message printed regardless
of whether any tests failed. Return values from all test functions were being
discarded. Now collected into a `results` list with an accurate pass/fail summary.

**Before:**
```python
test_query(token)
# ...
print("\n✅ All basic endpoints are functional!")
```
**After:**
```python
results = []
results.append(test_query(token))
# ...
failed = results.count(False)
if failed == 0:
    print("\n✅ All basic endpoints are functional!")
else:
    print(f"\n⚠️  {failed} test(s) failed. Check output above.")
```

---

## Files Changed
- `backend/test_system.py`