### PR TITLE
fix: query created_at not timestamp in digest active-user lookup (#202)

### DIFF
--- a/backend/app/services/digest.py
+++ b/backend/app/services/digest.py
@@ -14,15 +14,17 @@ DEFAULT_WINDOW_HOURS = 168
 async def _get_active_user_ids(window_hours: int) -> List[str]:
     """Return user_ids with memory activity in the window.
 
-    Uses the same `timestamp` field that the summarizer's timeline query
-    filters on, so we only digest users the summary would actually cover.
+    Filters on `created_at`, the BSON Date field used by the other memory
+    queries in the codebase (get_memory_stats, all_memories_filtered). The
+    `timestamp` field is stored as an ISO string, so a datetime `$gte`
+    predicate against it never matches in MongoDB.
     """
     db = get_db()
     if db is None:
         return []
     cutoff = datetime.utcnow() - timedelta(hours=window_hours)
     user_ids = await db["memories"].distinct(
-        "user_id", {"timestamp": {"$gte": cutoff}}
+        "user_id", {"created_at": {"$gte": cutoff}}
     )
     return [str(uid) for uid in user_ids if uid]
 

--- a/backend/tests/test_digest.py
+++ b/backend/tests/test_digest.py
@@ -125,6 +125,25 @@ class TestDigestService:
         assert generated_for == ["user_1", "user_2"]
         memories.distinct.assert_called_once()
 
+    async def test_get_active_user_ids_queries_created_at_not_timestamp(self, monkeypatch):
+        """The active-user query must filter on created_at (BSON Date), not the
+        timestamp string field, or it silently matches nothing in MongoDB."""
+        memories = MagicMock()
+        memories.distinct = AsyncMock(return_value=["user_1"])
+        db = _make_db({"memories": memories})
+        monkeypatch.setattr("app.services.digest.get_db", lambda: db)
+
+        from app.services.digest import _get_active_user_ids
+
+        result = await _get_active_user_ids(168)
+
+        assert result == ["user_1"]
+        memories.distinct.assert_called_once()
+        field, query = memories.distinct.call_args.args
+        assert field == "user_id"
+        assert "created_at" in query
+        assert "timestamp" not in query
+
     async def test_run_weekly_digests_skips_inactive_users(self, monkeypatch):
         """With no active users, no digests are generated."""
         memories = MagicMock()


### PR DESCRIPTION
## Summary

Fixes #202. The weekly digest scheduler silently generated zero digests every run because `_get_active_user_ids` queried the wrong field type in MongoDB.

## The bug

`_get_active_user_ids` in `app/services/digest.py` filtered:

```python
{"timestamp": {"$gte": cutoff}}   # cutoff is a datetime
```

But memories store two different time fields (`app/services/memory_store.py`):

- `timestamp` as an ISO **string** (`timestamp.isoformat()`)
- `created_at` as a BSON **Date** (datetime)

MongoDB's `$gte` only compares values of the same BSON type, so a datetime predicate never matches the string `timestamp` field. The query returned an empty list on every run, so `run_weekly_digests()` iterated over nothing and generated zero digests, even when users had recent activity.

The manual `POST /digest/generate` path was unaffected, since it takes `user_id` directly and doesn't go through this query, which is why the bug wasn't obvious.

## The fix

Changed the filter to `created_at`, the Date field that the other memory queries in the codebase already use (`get_memory_stats`, `all_memories_filtered`):

```python
{"created_at": {"$gte": cutoff}}
```

Also corrected the docstring, which claimed the function matched the summarizer's timeline field but described the wrong one (`get_recent_timeline` reads `created_at`).

## Tests

Added a test asserting `_get_active_user_ids` queries `created_at` and explicitly not `timestamp`, so this mismatch can't silently return. Existing digest tests still pass (11 total).

Let me know if anything looks off.