### PR TITLE
fix: route auth/reminder DB access through shared get_db() pool

### DIFF
--- a/backend/app/services/auth.py
+++ b/backend/app/services/auth.py
@@ -7,18 +7,12 @@ import bcrypt
 from fastapi import Depends, HTTPException, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from jose import JWTError, jwt
-from motor.motor_asyncio import AsyncIOMotorClient
 
 from app.config import settings
 from app.services.database import get_db
 
 
 logger = logging.getLogger(__name__)
-
-_mongo = AsyncIOMotorClient(settings.mongo_uri)
-_db = _mongo[settings.database_name]
-_users_col = _db["users"]
-_login_attempts_col = _db["login_attempts"]
 
 ACCESS_TOKEN_EXPIRE_MINUTES = 10080  # 7 days in minutes
 REFRESH_TOKEN_EXPIRE_DAYS = 30
@@ -104,10 +98,11 @@ def decode_access_token(token: str) -> Optional[Dict]:
 # ── User operations ───────────────────────────────────────────────────────────
 async def create_user(username: str, password: str) -> bool:
     username = username.lower().strip()
-    existing = await _users_col.find_one({"username": username})
+    db = get_db()
+    existing = await db["users"].find_one({"username": username})
     if existing:
         return False
-    await _users_col.insert_one({
+    await db["users"].insert_one({
         "username": username,
         "password_hash": hash_password(password),
         "created_at": datetime.utcnow(),
@@ -117,16 +112,19 @@ async def create_user(username: str, password: str) -> bool:
 
 async def authenticate_user(username: str, password: str) -> Optional[str]:
     username = username.lower().strip()
-    user = await _users_col.find_one({"username": username})
+    db = get_db()
+    user = await db["users"].find_one({"username": username})
     if not user or not verify_password(password, user["password_hash"]):
         return None
     return username
+
 
 # ── Account lockout (brute-force protection) ──────────────────────────────────
 async def get_lockout_seconds_remaining(username: str) -> int:
     """Return seconds remaining on an active lockout, or 0 if not locked."""
     username = username.lower().strip()
-    record = await _login_attempts_col.find_one({"username": username})
+    db = get_db()
+    record = await db["login_attempts"].find_one({"username": username})
     if not record:
         return 0
     locked_until = record.get("locked_until")
@@ -139,7 +137,8 @@ async def register_failed_login(username: str) -> None:
     """Record a failed attempt; lock the account once the threshold is hit."""
     username = username.lower().strip()
     now = datetime.utcnow()
-    record = await _login_attempts_col.find_one({"username": username})
+    db = get_db()
+    record = await db["login_attempts"].find_one({"username": username})
     failures = (record.get("failures", 0) if record else 0) + 1
 
     update = {"failures": failures, "last_failed_at": now}
@@ -150,7 +149,7 @@ async def register_failed_login(username: str) -> None:
             f"failures={failures} minutes={settings.login_lockout_minutes}"
         )
 
-    await _login_attempts_col.update_one(
+    await db["login_attempts"].update_one(
         {"username": username},
         {"$set": update},
         upsert=True,
@@ -160,19 +159,21 @@ async def register_failed_login(username: str) -> None:
 async def reset_login_attempts(username: str) -> None:
     """Clear any failure record on successful authentication."""
     username = username.lower().strip()
-    await _login_attempts_col.delete_one({"username": username})
+    db = get_db()
+    await db["login_attempts"].delete_one({"username": username})
 
 
 async def get_user_id_from_username(username: str) -> Optional[str]:
     """Get user_id from username."""
     username = username.lower().strip()
-    user = await _users_col.find_one({"username": username})
+    db = get_db()
+    user = await db["users"].find_one({"username": username})
     if not user:
         return None
     return str(user.get("_id")) if "_id" in user else username
 
 
-# ── FastAPI dependencies ─────────────────────────────────────────────────────────
+# ── FastAPI dependencies ──────────────────────────────────────────────────────
 _bearer = HTTPBearer()
 
 
@@ -188,6 +189,7 @@ async def get_current_user_id(
         )
     return username
 
+
 async def get_current_user(
     creds: HTTPAuthorizationCredentials = Depends(_bearer),
 ) -> Dict[str, str]:
@@ -197,11 +199,9 @@ async def get_current_user(
     Returns user context dict expected by older route handlers.
     """
     username = await verify_access_token(creds.credentials)
-
     if not username:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid or expired token",
         )
-
     return {"username": username}

--- a/backend/app/services/reminder_service.py
+++ b/backend/app/services/reminder_service.py
@@ -2,15 +2,9 @@ import logging
 from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional
 
-from motor.motor_asyncio import AsyncIOMotorClient
-from app.config import settings
+from app.services.database import get_db
 
 logger = logging.getLogger(__name__)
-
-_mongo = AsyncIOMotorClient(settings.mongo_uri)
-_db = _mongo[settings.database_name]
-_memories_col = _db["memories"]
-_alerts_col = _db["alerts"]
 
 # Intents that carry a meaningful date we should alert on
 ALERTABLE_INTENTS = {"meeting", "deadline", "reminder", "commitment"}
@@ -26,11 +20,14 @@ async def check_and_fire_reminders() -> int:
     for any that haven't been alerted yet.
     Returns the number of new alerts created.
     """
+    db = get_db()
+    memories_col = db["memories"]
+    alerts_col = db["alerts"]
+
     now = datetime.utcnow()
     window_end = now + timedelta(hours=LOOKAHEAD_HOURS)
 
-    # Find memories with a parsed date inside the lookahead window
-    cursor = _memories_col.find({
+    cursor = memories_col.find({
         "metadata.intent": {"$in": list(ALERTABLE_INTENTS)},
         "metadata.entities.dates": {"$exists": True, "$ne": []},
     })
@@ -54,13 +51,11 @@ async def check_and_fire_reminders() -> int:
                 continue
 
             try:
-                # Try to parse as ISO format first
                 if isinstance(parsed_str, str):
                     parsed_date = datetime.fromisoformat(parsed_str.replace("Z", "+00:00"))
                 else:
                     continue
             except (ValueError, TypeError):
-                # Try using dateparser as fallback
                 try:
                     import dateparser
                     parsed_date = dateparser.parse(parsed_str, settings={
@@ -69,25 +64,23 @@ async def check_and_fire_reminders() -> int:
                     })
                     if not parsed_date:
                         continue
-                except:
+                except Exception:
                     continue
 
-            # Only alert if the event is within the lookahead window
             if not (now <= parsed_date <= window_end):
                 continue
 
             memory_id = str(memory["_id"])
             user_id = memory.get("user_id", "unknown")
 
-            # Deduplication: skip if we already alerted for this memory + date
-            existing = await _alerts_col.find_one({
+            # Deduplication: skip if already alerted for this memory + date
+            existing = await alerts_col.find_one({
                 "memory_id": memory_id,
                 "parsed_date": parsed_str,
             })
             if existing:
                 continue
 
-            # Create alert record
             alert = {
                 "memory_id": memory_id,
                 "user_id": user_id,
@@ -98,7 +91,7 @@ async def check_and_fire_reminders() -> int:
                 "alerted_at": now,
                 "acknowledged": False,
             }
-            await _alerts_col.insert_one(alert)
+            await alerts_col.insert_one(alert)
             new_alert_count += 1
 
             logger.info(
@@ -121,8 +114,10 @@ async def get_upcoming_reminders(
     Fetch pending reminder alerts for a user from the alerts collection.
     Used by the /reminders/upcoming endpoint.
     """
+    db = get_db()
+    alerts_col = db["alerts"]
+
     now = datetime.utcnow()
-    window_end = now + timedelta(hours=hours)
 
     query: Dict[str, Any] = {
         "user_id": user_id,
@@ -132,7 +127,7 @@ async def get_upcoming_reminders(
         query["acknowledged"] = False
 
     reminders = []
-    cursor = _alerts_col.find(query).sort("due_in_minutes", 1)
+    cursor = alerts_col.find(query).sort("due_in_minutes", 1)
     async for doc in cursor:
         doc["_id"] = str(doc["_id"])
         reminders.append(doc)
@@ -143,7 +138,8 @@ async def get_upcoming_reminders(
 async def acknowledge_reminder(alert_id: str, user_id: str) -> bool:
     """Mark a reminder as acknowledged so it won't re-appear."""
     from bson import ObjectId
-    result = await _alerts_col.update_one(
+    db = get_db()
+    result = await db["alerts"].update_one(
         {"_id": ObjectId(alert_id), "user_id": user_id},
         {"$set": {"acknowledged": True}}
     )

--- a/backend/tests/test_account_lockout.py
+++ b/backend/tests/test_account_lockout.py
@@ -40,7 +40,9 @@ class TestAccountLockout:
         col.find_one = AsyncMock(return_value=None)
         col.update_one = AsyncMock(return_value=MagicMock(modified_count=1))
         col.delete_one = AsyncMock(return_value=MagicMock(deleted_count=1))
-        monkeypatch.setattr(auth_service, "_login_attempts_col", col)
+        mock_db = MagicMock()
+        mock_db.__getitem__ = MagicMock(return_value=col)
+        monkeypatch.setattr("app.services.auth.get_db", lambda: mock_db)
         return col
 
     async def test_no_record_means_not_locked(self, attempts_col):
@@ -107,9 +109,21 @@ class TestAccountLockout:
         """End-to-end: failures land 401, the (N+1)th request lands 429 with Retry-After."""
         fake_col = _FakeAttemptsCollection()
 
-        # Patch in both the service module (where the lockout funcs read the
-        # collection) and the route module (where they were imported by name).
-        monkeypatch.setattr(auth_service, "_login_attempts_col", fake_col)
+        # Route handler also calls get_db() for audit_logs and blacklisted_tokens;
+        # provide async-safe stubs so those calls don't hit a real server.
+        audit_col = MagicMock()
+        audit_col.insert_one = AsyncMock()
+        blacklist_col = MagicMock()
+        blacklist_col.find_one = AsyncMock(return_value=None)
+
+        mock_db = MagicMock()
+        mock_db.__getitem__ = MagicMock(side_effect=lambda name: {
+            "login_attempts": fake_col,
+            "audit_logs": audit_col,
+            "blacklisted_tokens": blacklist_col,
+        }.get(name, MagicMock()))
+
+        monkeypatch.setattr("app.services.auth.get_db", lambda: mock_db)
         monkeypatch.setattr(auth_service.settings, "login_max_failures", 3)
         monkeypatch.setattr(auth_service.settings, "login_lockout_minutes", 15)
 

--- a/backend/tests/test_reminders.py
+++ b/backend/tests/test_reminders.py
@@ -8,34 +8,40 @@ class TestReminders:
     """Test reminder functionality."""
 
     async def test_memory_with_date_and_alertable_intent_creates_reminder_alert(self, monkeypatch):
-        """Test that memory with date + alertable intent creates reminder alert."""
-        # Mock MongoDB collections
+        """Memory with alertable intent and a date in the lookahead window creates an alert."""
+        from datetime import datetime, timedelta
+
+        # Dynamic future date so the 24-hour window check passes
+        future_date = (datetime.utcnow() + timedelta(hours=1)).isoformat()
+
         mock_memories_col = MagicMock()
         mock_memories_col.find = MagicMock(return_value=_async_cursor([
             {
                 "_id": "mem_1",
                 "user_id": "test_user",
-                "text": "Meeting tomorrow at 2pm",
+                "text": "Meeting in an hour",
                 "metadata": {
                     "intent": "meeting",
-                    "entities": {
-                        "dates": ["2026-04-15T14:00:00"]
-                    }
-                }
+                    "entities": {"dates": [future_date]},
+                },
             }
         ]))
-        
+
         mock_alerts_col = MagicMock()
         mock_alerts_col.find_one = AsyncMock(return_value=None)
         mock_alerts_col.insert_one = AsyncMock()
-        
-        monkeypatch.setattr("app.services.reminder_service._memories_col", mock_memories_col)
-        monkeypatch.setattr("app.services.reminder_service._alerts_col", mock_alerts_col)
-        
+
+        mock_db = MagicMock()
+        mock_db.__getitem__ = MagicMock(side_effect=lambda name: {
+            "memories": mock_memories_col,
+            "alerts": mock_alerts_col,
+        }.get(name, MagicMock()))
+        monkeypatch.setattr("app.services.reminder_service.get_db", lambda: mock_db)
+
         from app.services.reminder_service import check_and_fire_reminders
         count = await check_and_fire_reminders()
-        
-        assert count >= 0
+
+        assert count >= 1
         mock_alerts_col.insert_one.assert_called()
 
     async def test_get_upcoming_reminders_returns_correct_reminders_within_time_window(self, client: AsyncClient, monkeypatch, auth_headers):

--- a/backend/tests/test_system.py
+++ b/backend/tests/test_system.py
@@ -15,7 +15,7 @@ async def test_status_ok(client: AsyncClient):
 # ── Auth: signup ──────────────────────────────────────────────────────────────
 @pytest.mark.asyncio
 async def test_signup_creates_user(client: AsyncClient, mock_db, monkeypatch):
-    monkeypatch.setattr("app.services.auth._users_col", mock_db)
+    monkeypatch.setattr("app.services.auth.get_db", lambda: {"users": mock_db, "login_attempts": mock_db})
 
     response = await client.post("/auth/signup", json={
         "username": "newuser",
@@ -29,7 +29,7 @@ async def test_signup_creates_user(client: AsyncClient, mock_db, monkeypatch):
 async def test_signup_duplicate_rejected(client: AsyncClient, mock_db, monkeypatch):
     from unittest.mock import AsyncMock
     mock_db.find_one = AsyncMock(return_value={"username": "existing"})
-    monkeypatch.setattr("app.services.auth._users_col", mock_db)
+    monkeypatch.setattr("app.services.auth.get_db", lambda: {"users": mock_db, "login_attempts": mock_db})
 
     response = await client.post("/auth/signup", json={
         "username": "existing",
@@ -48,8 +48,7 @@ async def test_login_returns_token_pair(client: AsyncClient, mock_db, monkeypatc
         "username": "test_user",
         "password_hash": hash_password("correct_password"),
     })
-    monkeypatch.setattr("app.services.auth._users_col", mock_db)
-
+    monkeypatch.setattr("app.services.auth.get_db", lambda: {"users": mock_db, "login_attempts": mock_db})
     response = await client.post("/auth/login", json={
         "username": "test_user",
         "password": "correct_password"
@@ -70,8 +69,7 @@ async def test_login_wrong_password_rejected(client: AsyncClient, mock_db, monke
         "username": "test_user",
         "password_hash": hash_password("correct_password"),
     })
-    monkeypatch.setattr("app.services.auth._users_col", mock_db)
-
+    monkeypatch.setattr("app.services.auth.get_db", lambda: {"users": mock_db, "login_attempts": mock_db})
     response = await client.post("/auth/login", json={
         "username": "test_user",
         "password": "wrong_password"


### PR DESCRIPTION
Closes #190

---

### Problem

`app/services/auth.py` and `app/services/reminder_service.py` each called `AsyncIOMotorClient(settings.mongo_uri)` at **module import time**, creating connections that were:

- **Never closed** by `close_mongo_connection()` on shutdown
- **Outside the shared pool** - `maxPoolSize`, timeouts configured in `database.py` had no effect on these clients
- **Crash-at-startup** if Mongo was unreachable at import time 
- **Untestable via `get_db()` mocks** - three different DB-access patterns in one codebase

### Fix

Removed all module-level `AsyncIOMotorClient` instantiation from both files. Every collection access now goes through `get_db()["collection_name"]` inside the function body, consistent with `digest.py` and the rest of the app.

**`auth.py`** - removed `_mongo`, `_users_col`, `_login_attempts_col`; `get_db()` called inside `create_user`, `authenticate_user`,
`get_lockout_seconds_remaining`, `register_failed_login`, `reset_login_attempts`.

**`reminder_service.py`** - removed `_mongo`, `_db`, `_memories_col`, `_alerts_col`; `get_db()` called inside `check_and_fire_reminders`, `get_upcoming_reminders`, `acknowledge_reminder`.

### Test changes

Three test files patched the now-removed module-level variables directly
(`_users_col`, `_login_attempts_col`, `_memories_col`, `_alerts_col`).
These were updated to patch `get_db` instead - necessary consequence of the fix, not refactoring.

| File | Change |
|---|---|
| `tests/test_account_lockout.py` | patch `get_db` instead of `_login_attempts_col` |
| `tests/test_system.py` | patch `get_db` instead of `_users_col` |
| `tests/test_reminders.py` | patch `get_db` instead of `_memories_col`/`_alerts_col` |

### Pre-existing failure (not caused by this PR)

`test_login_route_returns_429_after_threshold` fails because `exception_handlers.py`'s custom `http_exception_handler` builds its own `JSONResponse` without forwarding `exc.headers`, silently dropping the `Retry-After` header on every `HTTPException` in the app. This exists on `main` independently of this PR and is unrelated to connection pooling.

### Notes

- `memory_store.py` has the same standalone-client pattern - intentionally left out of scope per maintainer guidance, tracked separately
- No behaviour changes - pure architectural fix routing DB access through the existing shared lifecycle managed by `database.py`