### PR TITLE
fix: normalize datetimes to UTC-aware in reminder scan to prevent tz comparison crash (#215)

### DIFF
--- a/backend/app/services/reminder_service.py
+++ b/backend/app/services/reminder_service.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional
 
 from app.services.database import get_db
@@ -24,7 +24,7 @@ async def check_and_fire_reminders() -> int:
     memories_col = db["memories"]
     alerts_col = db["alerts"]
 
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     window_end = now + timedelta(hours=LOOKAHEAD_HOURS)
 
     cursor = memories_col.find({
@@ -66,6 +66,9 @@ async def check_and_fire_reminders() -> int:
                         continue
                 except Exception:
                     continue
+
+            if parsed_date.tzinfo is None:
+                parsed_date = parsed_date.replace(tzinfo=timezone.utc)
 
             if not (now <= parsed_date <= window_end):
                 continue
@@ -117,7 +120,7 @@ async def get_upcoming_reminders(
     db = get_db()
     alerts_col = db["alerts"]
 
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
 
     query: Dict[str, Any] = {
         "user_id": user_id,

--- a/backend/tests/test_reminders.py
+++ b/backend/tests/test_reminders.py
@@ -44,6 +44,85 @@ class TestReminders:
         assert count >= 1
         mock_alerts_col.insert_one.assert_called()
 
+    async def test_z_suffixed_date_does_not_crash_comparison(self, monkeypatch):
+        """A memory date ending in 'Z' (timezone-aware) must not raise
+        'can't compare offset-naive and offset-aware datetimes'."""
+        from datetime import datetime, timedelta, timezone
+
+        # Aware future date, serialized with a trailing Z (the crashing case)
+        future_z = (
+            datetime.now(timezone.utc) + timedelta(hours=1)
+        ).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+        mock_memories_col = MagicMock()
+        mock_memories_col.find = MagicMock(return_value=_async_cursor([
+            {
+                "_id": "mem_z",
+                "user_id": "test_user",
+                "text": "Meeting soon",
+                "metadata": {
+                    "intent": "meeting",
+                    "entities": {"dates": [future_z]},
+                },
+            }
+        ]))
+
+        mock_alerts_col = MagicMock()
+        mock_alerts_col.find_one = AsyncMock(return_value=None)
+        mock_alerts_col.insert_one = AsyncMock()
+
+        mock_db = MagicMock()
+        mock_db.__getitem__ = MagicMock(side_effect=lambda name: {
+            "memories": mock_memories_col,
+            "alerts": mock_alerts_col,
+        }.get(name, MagicMock()))
+        monkeypatch.setattr("app.services.reminder_service.get_db", lambda: mock_db)
+
+        from app.services.reminder_service import check_and_fire_reminders
+
+        # Must not raise; the Z-date is aware and now is aware after the fix.
+        count = await check_and_fire_reminders()
+        assert count >= 1
+        mock_alerts_col.insert_one.assert_called()
+
+    async def test_naive_date_still_processed_without_error(self, monkeypatch):
+        """A naive date (no offset, e.g. from the dateparser fallback path)
+        is coerced to UTC and still compared without error."""
+        from datetime import datetime, timedelta
+
+        # Naive future date (no Z, no offset)
+        future_naive = (datetime.utcnow() + timedelta(hours=1)).strftime("%Y-%m-%dT%H:%M:%S")
+
+        mock_memories_col = MagicMock()
+        mock_memories_col.find = MagicMock(return_value=_async_cursor([
+            {
+                "_id": "mem_naive",
+                "user_id": "test_user",
+                "text": "Naive meeting",
+                "metadata": {
+                    "intent": "meeting",
+                    "entities": {"dates": [future_naive]},
+                },
+            }
+        ]))
+
+        mock_alerts_col = MagicMock()
+        mock_alerts_col.find_one = AsyncMock(return_value=None)
+        mock_alerts_col.insert_one = AsyncMock()
+
+        mock_db = MagicMock()
+        mock_db.__getitem__ = MagicMock(side_effect=lambda name: {
+            "memories": mock_memories_col,
+            "alerts": mock_alerts_col,
+        }.get(name, MagicMock()))
+        monkeypatch.setattr("app.services.reminder_service.get_db", lambda: mock_db)
+
+        from app.services.reminder_service import check_and_fire_reminders
+
+        count = await check_and_fire_reminders()
+        assert count >= 1
+        mock_alerts_col.insert_one.assert_called()
+
     async def test_get_upcoming_reminders_returns_correct_reminders_within_time_window(self, client: AsyncClient, monkeypatch, auth_headers):
         """Test that GET /reminders/upcoming returns correct reminders within time window."""
         # Mock get_upcoming_reminders


### PR DESCRIPTION
## Summary

Fixes #215. `check_and_fire_reminders` crashed with `TypeError: can't compare offset-naive and offset-aware datetimes` whenever a memory's date string carried a `Z`/UTC offset, aborting the entire reminder scan.

## The bug

In `backend/app/services/reminder_service.py`, `now` was naive (`datetime.utcnow()`), but `datetime.fromisoformat(parsed_str.replace("Z", "+00:00"))` produces a timezone-aware datetime for any `...Z` date. The window check `now <= parsed_date <= window_end` compared naive against aware and raised. Since that comparison wasn't guarded, the exception propagated out of the `async for` loop and killed the whole scan. The scheduler runs every 15 minutes, so a single `Z`/offset date in the memories collection meant no reminders fired for anyone.

The mixed-format situation is real: the ISO-with-`Z` path yields aware datetimes while the `dateparser` fallback (for phrases like "next Monday") yields naive ones, so the same collection produces both.

## The fix

Normalized everything to a single convention (UTC-aware), scoped to `reminder_service.py`:

- `now` is now `datetime.now(timezone.utc)` (aware), so `window_end` is aware too.
- After parsing (either branch), a naive `parsed_date` is coerced to UTC with `parsed_date.replace(tzinfo=timezone.utc)` before the comparison.

This makes both sides of the window check (and the `parsed_date - now` arithmetic) always aware, regardless of which parse path produced the date.

I also changed `now` in `get_upcoming_reminders` to `datetime.now(timezone.utc)` for consistency. Since `check_and_fire_reminders` now stores `alerted_at` as an aware datetime, keeping the `get_upcoming_reminders` query bound naive would create the same naive-vs-aware mismatch on the `alerted_at` `$gte` filter, so making it aware keeps the whole file on one convention. Happy to revert that one line if you'd prefer to keep the change even more minimal.

## Tests

Added two regression tests to `tests/test_reminders.py`, matching the existing mock style:

- `test_z_suffixed_date_does_not_crash_comparison` — feeds a `...Z` (aware) date through `check_and_fire_reminders` and asserts it doesn't raise and the alert fires. This fails on the current code with the reported `TypeError`.
- `test_naive_date_still_processed_without_error` — feeds a naive date (the dateparser-fallback shape) and asserts it's processed without error.

Both pass with the fix. (The three existing endpoint tests in this file fail locally with 401 because they need a live database for token verification, which fails closed without one — that's pre-existing and unrelated to this change; they pass in CI.)

Let me know if anything looks off.