### PR TITLE
Fix WebSocket disconnect to target the specific closing connection

### DIFF
--- a/backend/app/routes/websocket.py
+++ b/backend/app/routes/websocket.py
@@ -8,36 +8,46 @@ router = APIRouter()
 
 
 class ConnectionManager:
-    """Manages WebSocket connections for real-time updates."""
+    """Manages WebSocket connections for real-time updates.
+
+    Tracks a set of connections per user_id so a user can briefly hold more
+    than one active connection, e.g. during a reconnect.
+    """
 
     def __init__(self):
-        self.active_connections: dict[str, WebSocket] = {}
+        self.active_connections: dict[str, set[WebSocket]] = {}
 
     async def connect(self, websocket: WebSocket, user_id: str):
-        await websocket.accept()
-        self.active_connections[user_id] = websocket
+        """Register an already-accepted socket under user_id (caller must accept() first)."""
+        self.active_connections.setdefault(user_id, set()).add(websocket)
         logger.info(f"WebSocket connected for user {user_id}")
 
-    def disconnect(self, user_id: str):
-        if user_id in self.active_connections:
+    def disconnect(self, user_id: str, websocket: WebSocket):
+        """Remove one connection for user_id, leaving any others intact."""
+        connections = self.active_connections.get(user_id)
+        if not connections or websocket not in connections:
+            return
+        connections.discard(websocket)
+        if not connections:
             del self.active_connections[user_id]
-            logger.info(f"WebSocket disconnected for user {user_id}")
+        logger.info(f"WebSocket disconnected for user {user_id}")
 
     async def send_personal_message(self, message: dict, user_id: str):
-        if user_id in self.active_connections:
-            try:
-                await self.active_connections[user_id].send_json(message)
-            except Exception as e:
-                logger.error(f"Error sending WebSocket message to {user_id}: {e}")
-                self.disconnect(user_id)
-
-    async def broadcast(self, message: dict):
-        """Send message to all connected users."""
-        for user_id, connection in self.active_connections.items():
+        for connection in list(self.active_connections.get(user_id, ())):
             try:
                 await connection.send_json(message)
             except Exception as e:
-                logger.error(f"Error broadcasting to {user_id}: {e}")
+                logger.error(f"Error sending WebSocket message to {user_id}: {e}")
+                self.disconnect(user_id, connection)
+
+    async def broadcast(self, message: dict):
+        """Send message to all connected users."""
+        for user_id, connections in list(self.active_connections.items()):
+            for connection in list(connections):
+                try:
+                    await connection.send_json(message)
+                except Exception as e:
+                    logger.error(f"Error broadcasting to {user_id}: {e}")
 
 
 manager = ConnectionManager()
@@ -79,8 +89,7 @@ async def websocket_endpoint(websocket: WebSocket):
         await websocket.close(code=4001, reason="Authentication failed")
         return
 
-    manager.active_connections[user_id] = websocket
-    logger.info(f"WebSocket connected for user {user_id}")
+    await manager.connect(websocket, user_id)
 
     try:
         while True:
@@ -93,7 +102,7 @@ async def websocket_endpoint(websocket: WebSocket):
                 pass
 
     except WebSocketDisconnect:
-        manager.disconnect(user_id)
+        manager.disconnect(user_id, websocket)
     except Exception as e:
         logger.error(f"WebSocket error for user {user_id}: {e}")
-        manager.disconnect(user_id)
+        manager.disconnect(user_id, websocket)

--- a/backend/tests/test_websocket_connection_identity.py
+++ b/backend/tests/test_websocket_connection_identity.py
@@ -1,0 +1,112 @@
+"""
+Tests for ConnectionManager's per-connection identity tracking.
+
+Verifies that a user can hold multiple simultaneous WebSocket connections
+(e.g. during a quick reconnect) and that disconnecting one connection never
+drops a different, still-active connection for the same user_id.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.routes.websocket import ConnectionManager
+
+def make_socket():
+    """Return a fresh mock WebSocket with an async send_json."""
+    socket = MagicMock()
+    socket.send_json = AsyncMock()
+    return socket
+
+
+@pytest.fixture
+def manager():
+    return ConnectionManager()
+
+
+class TestConnectionIdentity:
+    """Two overlapping connections for the same user must be tracked independently."""
+
+    async def test_connect_tracks_multiple_sockets_for_same_user(self, manager):
+        """Both sockets must be active after connecting twice for one user_id."""
+        old_socket, new_socket = make_socket(), make_socket()
+
+        await manager.connect(old_socket, "user-1")
+        await manager.connect(new_socket, "user-1")
+
+        assert manager.active_connections["user-1"] == {old_socket, new_socket}
+
+    async def test_disconnecting_older_socket_keeps_newer_socket_active(self, manager):
+        """Regression test for #229: closing the older connection must not
+        remove the newer, still-active connection from routing."""
+        old_socket, new_socket = make_socket(), make_socket()
+        await manager.connect(old_socket, "user-1")
+        await manager.connect(new_socket, "user-1")
+
+        manager.disconnect("user-1", old_socket)
+
+        assert old_socket not in manager.active_connections["user-1"]
+        assert new_socket in manager.active_connections["user-1"]
+
+    async def test_disconnecting_last_socket_removes_user_entry(self, manager):
+        """Once no sockets remain for a user, the dict entry itself is cleaned up."""
+        socket = make_socket()
+        await manager.connect(socket, "user-1")
+
+        manager.disconnect("user-1", socket)
+
+        assert "user-1" not in manager.active_connections
+
+    async def test_disconnect_is_noop_for_unknown_socket(self, manager):
+        """Disconnecting a socket that was never registered must not raise
+        or affect other active connections for that user."""
+        active_socket, unknown_socket = make_socket(), make_socket()
+        await manager.connect(active_socket, "user-1")
+
+        manager.disconnect("user-1", unknown_socket)
+
+        assert manager.active_connections["user-1"] == {active_socket}
+
+    async def test_disconnect_is_noop_for_unknown_user(self, manager):
+        """Disconnecting for a user_id with no active connections must not raise."""
+        manager.disconnect("ghost-user", make_socket())
+
+
+class TestMessageFanOut:
+    """send_personal_message and broadcast must reach every connection a user holds."""
+
+    async def test_send_personal_message_reaches_all_sockets_for_user(self, manager):
+        """A message sent to a user_id must reach every socket that user holds."""
+        first, second = make_socket(), make_socket()
+        await manager.connect(first, "user-1")
+        await manager.connect(second, "user-1")
+
+        await manager.send_personal_message({"type": "update"}, "user-1")
+
+        first.send_json.assert_awaited_once_with({"type": "update"})
+        second.send_json.assert_awaited_once_with({"type": "update"})
+
+    async def test_send_personal_message_drops_only_failing_socket(self, manager):
+        """A send failure on one socket must not affect a sibling socket for
+        the same user, and must remove only the socket that failed."""
+        healthy, broken = make_socket(), make_socket()
+        broken.send_json.side_effect = RuntimeError("connection reset")
+        await manager.connect(healthy, "user-1")
+        await manager.connect(broken, "user-1")
+
+        await manager.send_personal_message({"type": "update"}, "user-1")
+
+        assert manager.active_connections["user-1"] == {healthy}
+
+    async def test_broadcast_reaches_every_connection_across_users(self, manager):
+        """broadcast() must reach every socket for every user, not just one per user."""
+        u1_socket, u2_first, u2_second = make_socket(), make_socket(), make_socket()
+        await manager.connect(u1_socket, "user-1")
+        await manager.connect(u2_first, "user-2")
+        await manager.connect(u2_second, "user-2")
+
+        await manager.broadcast({"type": "announcement"})
+
+        u1_socket.send_json.assert_awaited_once_with({"type": "announcement"})
+        u2_first.send_json.assert_awaited_once_with({"type": "announcement"})
+        u2_second.send_json.assert_awaited_once_with({"type": "announcement"})


### PR DESCRIPTION
## Summary
Fixes #229. Connections were tracked as `Dict[user_id, WebSocket]`, so a user could only ever have one connection on record. The endpoint also bypassed `connect()`, writing to `active_connections` inline, and `disconnect(user_id)` deleted by user_id alone with no check on which socket was actually closing. During a quick reconnect, the older connection closing would silently knock the newer, still-active one out of routing.

`active_connections` is now `Dict[user_id, Set[WebSocket]]`. `disconnect()` takes the specific websocket and removes only that one, leaving any others intact. The endpoint routes registration through `manager.connect()` instead of mutating the dict inline, and `send_personal_message`/`broadcast` now iterate every connection a user holds instead of assuming one.

No changes to the wire-level API - the auth handshake and ping/pong are untouched. `ConnectionManager` isn't imported anywhere outside this file, so nothing else depends on the old `disconnect(user_id)` signature.

## Test plan
- [x] `pytest tests/test_websocket_connection_identity.py -v` - 8 new tests covering multi-connection tracking, targeted disconnect, and message fan-out to all of a user's sockets. All passing.
- [x] Confirmed against the unmodified code that the core regression test fails without this fix (an older socket's disconnect wipes out a newer, still-active one), confirming it's a genuine regression test.

## Screenshots (if UI)
N/A - backend-only fix, no UI changes.