### PR TITLE
fix: execute persistent queue tasks via a consumer loop

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -8,7 +8,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from app.config import settings
 from app.core.logging_config import setup_logging
-from app.workers.background_worker import start_worker
+from app.workers.background_worker import start_worker, stop_worker
 from app.services.reminder_service import check_and_fire_reminders
 from app.services.digest import run_weekly_digests
 from app.services.database import get_db
@@ -160,6 +160,7 @@ async def lifespan(app: FastAPI):
 
     # Shutdown
     _scheduler.shutdown(wait=False)
+    await stop_worker()
     await close_mongo_connection()
     logger.info("Verath shut down cleanly")
 

--- a/backend/app/workers/background_worker.py
+++ b/backend/app/workers/background_worker.py
@@ -1,13 +1,12 @@
 import asyncio
 import logging
+import traceback
 import uuid
-from datetime import datetime
-from enum import Enum
 from typing import Any, Callable, Dict, List, Optional
 
-from app.config import settings
 from app.workers.task_queue import (
     Task,
+    TaskStatus,
     TaskType,
     task_queue,
 )
@@ -15,92 +14,58 @@ from app.workers.task_queue import (
 logger = logging.getLogger(__name__)
 
 
-class TaskStatus(str, Enum):
-    PENDING = "pending"
-    PROCESSING = "processing"
-    COMPLETED = "completed"
-    FAILED = "failed"
-    DEAD = "dead"
-
-
-# Legacy → persistent queue state mapping used during migration.
-LEGACY_TO_PERSISTENT_STATUS = {
-    "PENDING": "QUEUED",
-    "PROCESSING": "PROCESSING",
-    "COMPLETED": "COMPLETED",
-    "FAILED": "FAILED",
-    "DEAD": "DEAD_LETTER",
-}
-
-
 # ============================================================================
-# Queue Migration Strategy
+# Persistent Task Queue Worker
 # ============================================================================
 #
-# Phase 1 (current):
-# - Preserve legacy background_worker interfaces
-# - Delegate orchestration behavior to task_queue.py
-# - Maintain backward compatibility for existing imports/routes
+# task_queue.py is the single orchestration backend: it owns persistence,
+# atomic claiming, and retry/dead-letter handling. This module is
+# responsible for the two things layered on top of that backend:
 #
-# Phase 2:
-# - Align task status semantics between legacy and persistent queues
-# - Remove duplicated retry/dead-letter orchestration paths
-#
-# Phase 3:
-# - Fully remove deprecated in-memory queue implementation
-# - Use task_queue.py as the single orchestration backend
-#
-# NOTE:
-# The in-memory queue remains temporarily as a compatibility layer during the
-# staged migration toward persistent queue orchestration.
+#   1. Turning public "enqueue a recording / compression job" calls into a
+#      structured (task_type, payload) record that task_queue can persist
+#      and hand back later — a callable can't survive a process restart, so
+#      no closures are stored, only plain data.
+#   2. Running the consumer loop that dequeues claimed tasks, dispatches
+#      each one to the handler registered for its task_type, and reports
+#      the outcome back through task_queue's existing status/retry API.
 # ============================================================================
 
-# Deprecated legacy in-memory queue retained temporarily for compatibility.
-_queue: asyncio.Queue = asyncio.Queue()
+POLL_INTERVAL_SECONDS = 5
+BASE_RETRY_DELAY_SECONDS = 30
 
-_worker_running = False
-
+_consumer_task: Optional[asyncio.Task] = None
 
 # ── Public: enqueue a job ────────────────────────────────────────────────────
 async def enqueue_task(
-    func: Callable,
-    args: tuple = (),
-    kwargs: Optional[Dict[str, Any]] = None,
-    task_name: str = "unnamed",
+    task_type: TaskType,
+    payload: Dict[str, Any],
+    user_id: str = "system",
 ) -> str:
     """
-    Enqueue a task using the persistent Mongo-backed queue backend.
+    Enqueue a task on the persistent Mongo-backed queue.
 
-    This preserves the existing background worker interface while
-    delegating orchestration behavior to task_queue.py.
+    payload must be JSON/BSON-serializable - it's what gets handed to the
+    task_type's registered handler once the consumer loop dequeues the
+    task, possibly after a restart, so it has to fully describe the work
+    on its own rather than closing over local variables.
     """
 
     task_id = str(uuid.uuid4())
-    kwargs = kwargs or {}
-
-    # Infer task type
-    if "record" in task_name.lower():
-        task_type = TaskType.RECORDING
-    else:
-        task_type = TaskType.COMPRESSION
 
     task = Task(
         task_id=task_id,
         task_type=task_type,
-        payload={
-            "task_name": task_name,
-            "args_repr": str(args)[:500],
-            "kwargs_repr": str(kwargs)[:500],
-        },
-        user_id="system",
+        payload=payload,
+        user_id=user_id,
     )
 
     success = await task_queue.enqueue(task)
 
     if not success:
-        raise RuntimeError(f"Failed to enqueue task: {task_name}")
+        raise RuntimeError(f"Failed to enqueue task: {task_type.value}")
 
-    logger.info(f"Enqueued persistent task {task_id} ({task_name})")
+    logger.info(f"Enqueued persistent task {task_id} ({task_type.value})")
 
     return task_id
 
@@ -118,108 +83,141 @@ async def get_task_status(task_id: str) -> Optional[Dict[str, Any]]:
         return None
 
 
-# ── Legacy retry compatibility layer ─────────────────────────────────────────
+# ── Task dispatch: task_type → handler ───────────────────────────────────────
 #
-# NOTE:
-# Legacy retry/dead-letter orchestration paths are retained temporarily
-# during staged migration toward the persistent task queue backend.
-#
-# New task orchestration should use task_queue.py directly.
-#
-async def _run_with_retry(
-    task_id: str,
-    task_name: str,
-    func: Callable,
-    args: tuple,
-    kwargs: dict,
-):
-    """
-    Deprecated compatibility wrapper retained during migration.
+# Handlers take the task's persisted payload and user_id and do the actual
+# work. They should let exceptions propagate — _process_task() below is
+# what decides whether a failure means a retry or a dead-letter move.
+async def _handle_recording_task(payload: Dict[str, Any], user_id: str) -> None:
+    """Record and transcribe a session, then store it as a memory."""
 
-    The persistent queue backend should handle retry orchestration.
-    """
+    from app.services.audio import record_audio
+    from app.services.pipeline import process_audio
+
+    file_path = record_audio(
+        filename=payload.get("filename"),
+        duration=payload.get("duration"),
+    )
+
+    await process_audio(file_path, user_id)
+
+async def _handle_compression_task(payload: Dict[str, Any], user_id: str) -> None:
+    """Run daily memory-lifecycle promotion and archival for a user."""
+
+    from app.db.memory_lifecycle import memory_lifecycle_manager
+
+    await memory_lifecycle_manager.auto_promote_important_memories(user_id)
+    await memory_lifecycle_manager.enforce_lifecycle_limits(user_id)
+
+
+TASK_HANDLERS: Dict[TaskType, Callable[[Dict[str, Any], str], Any]] = {
+    TaskType.RECORDING: _handle_recording_task,
+    TaskType.COMPRESSION: _handle_compression_task,
+}
+
+
+# ── Consumer loop ─────────────────────────────────────────────────────────────
+async def _process_task(task: Task) -> None:
+    """Run a single claimed task and report the outcome back to task_queue."""
+
+    handler = TASK_HANDLERS.get(task.task_type)
+
+    if handler is None:
+        error = f"No handler registered for task type: {task.task_type}"
+        logger.error(error)
+        await task_queue.mark_for_retry(
+            task.task_id,
+            error_message=error,
+            stack_trace="",
+            retry_delay=BASE_RETRY_DELAY_SECONDS,
+        )
+        return
 
     try:
-        if asyncio.iscoroutinefunction(func):
-            await func(*args, **kwargs)
-        else:
-            await asyncio.get_event_loop().run_in_executor(
-                None,
-                lambda: func(*args, **kwargs),
-            )
-
-        logger.info(
-            f"Legacy compatibility task completed: "
-            f"{task_id} ({task_name})"
-        )
+        await handler(task.payload, task.user_id)
+        await task_queue.update_status(task.task_id, TaskStatus.COMPLETED)
+        logger.info(f"Task {task.task_id} ({task.task_type.value}) completed")
 
     except Exception as e:
+        retry_delay = BASE_RETRY_DELAY_SECONDS * (2**task.retry_count)
         logger.error(
-            f"Legacy compatibility retry path failed "
-            f"for {task_id}: {e}"
+            f"Task {task.task_id} ({task.task_type.value}) failed: {e}",
+            exc_info=True,
         )
-        raise
+        await task_queue.mark_for_retry(
+            task.task_id,
+            error_message=str(e),
+            stack_trace=traceback.format_exc(),
+            retry_delay=retry_delay,
+        )
 
 
-# ── Worker loop ──────────────────────────────────────────────────────────────
-#
-# NOTE:
-# Deprecated legacy worker loop retained temporarily for backward
-# compatibility. Active orchestration has been migrated toward
-# task_queue.py.
-#
-# This loop should no longer receive newly enqueued tasks.
-#
-async def _worker_loop():
-    global _worker_running
+async def _consumer_loop() -> None:
+    """
+    Continuously poll the persistent queue and execute claimed tasks.
 
-    _worker_running = True
+    Runs for the lifetime of the app (started from main.py's lifespan).
+    Each iteration dequeues a batch of ready tasks and runs them one at a
+    time; it only sleeps when the queue comes back empty, so a backlog
+    drains without waiting out the poll interval between every task.
+    """
 
-    logger.info("Legacy background worker loop started")
+    logger.info("Persistent task queue consumer loop started")
 
     while True:
         try:
-            task_id, task_name, func, args, kwargs = await _queue.get()
+            tasks = await task_queue.dequeue()
 
-            await _run_with_retry(
-                task_id,
-                task_name,
-                func,
-                args,
-                kwargs,
-            )
+            if not tasks:
+                await asyncio.sleep(POLL_INTERVAL_SECONDS)
+                continue
 
-            _queue.task_done()
+            for task in tasks:
+                await _process_task(task)
 
         except asyncio.CancelledError:
-            logger.info("Legacy background worker shutting down")
-            break
+            logger.info("Persistent task queue consumer loop shutting down")
+            raise
 
         except Exception as e:
-            logger.error(f"Unexpected worker loop error: {e}")
+            logger.error(f"Unexpected consumer loop error: {e}", exc_info=True)
+            await asyncio.sleep(POLL_INTERVAL_SECONDS)
 
 
-def start_worker():
+def start_worker() -> None:
     """
-    Backward-compatible startup hook.
+    Schedule the persistent task queue consumer loop as a background task.
 
-    Legacy in-memory orchestration has been deprecated in favor
-    of the persistent Mongo-backed queue implementation in
-    task_queue.py.
-
-    This compatibility layer intentionally preserves the existing
-    public worker interface while migration occurs incrementally.
+    Called once from the FastAPI lifespan on startup, after the Mongo
+    connection is established.
     """
 
-    logger.info(
-        "Legacy background worker startup skipped "
-        "(persistent task queue is now primary)"
-    )
+    global _consumer_task
+    _consumer_task = asyncio.create_task(_consumer_loop())
+    logger.info("Persistent task queue consumer loop scheduled")
 
 
-# ── Background worker compatibility wrapper ──────────────────────────────────
+async def stop_worker() -> None:
+    """Cancel the consumer loop and wait for it to exit, for clean shutdown."""
+ 
+    global _consumer_task
+
+    if _consumer_task is None:
+        return
+
+    _consumer_task.cancel()
+    try:
+        await _consumer_task
+    except asyncio.CancelledError:
+        pass
+
+    _consumer_task = None
+    logger.info("Persistent task queue consumer loop stopped")
+
+
+# ── Background worker public interface ───────────────────────────────────────
 class BackgroundWorker:
-    """Compatibility wrapper for background worker functionality."""
+    """Public interface for enqueueing and inspecting persistent queue tasks."""
 
     async def enqueue_recording(
         self,
@@ -228,26 +226,16 @@ class BackgroundWorker:
     ) -> str:
         """Enqueue recording session processing."""
 
-        from app.services.pipeline import process_audio
-
-        async def process_recording():
-            try:
-                from app.services.audio import record_audio
-
-                file_path = record_audio(
-                    filename=session.filename,
-                    duration=session.duration,
-                )
-
-                await process_audio(file_path, user_id)
-
-            except Exception as e:
-                logger.error(f"Recording processing failed: {e}")
-                raise
+        payload = {
+            "filename": session.filename,
+            "duration": session.duration,
+            "session_type": session.session_type,
+        }
 
         return await enqueue_task(
-            func=process_recording,
-            task_name=f"recording_{session.session_type}",
+            task_type=TaskType.RECORDING,
+            payload=payload,
+            user_id=user_id,
         )
 
     async def get_task_status(
@@ -264,25 +252,10 @@ class BackgroundWorker:
     ) -> str:
         """Schedule daily memory compression."""
 
-        from app.db.memory_lifecycle import memory_lifecycle_manager
-
-        async def compress_memories():
-            try:
-                await memory_lifecycle_manager.auto_promote_important_memories(
-                    user_id
-                )
-
-                await memory_lifecycle_manager.enforce_lifecycle_limits(
-                    user_id
-                )
-
-            except Exception as e:
-                logger.error(f"Compression failed: {e}")
-                raise
-
         return await enqueue_task(
-            func=compress_memories,
-            task_name="daily_compression",
+            task_type=TaskType.COMPRESSION,
+            payload={},
+            user_id=user_id,
         )
 
     async def get_queue_stats(self) -> Dict[str, Any]:

--- a/backend/tests/test_background_worker.py
+++ b/backend/tests/test_background_worker.py
@@ -1,3 +1,5 @@
+from types import SimpleNamespace
+
 import pytest
 from unittest.mock import AsyncMock, MagicMock
 
@@ -9,7 +11,7 @@ class TestBackgroundWorker:
         self,
         monkeypatch,
     ):
-        """Test enqueue_task delegates to persistent queue backend."""
+        """enqueue_recording must persist a reconstructable RECORDING task."""
 
         mock_queue_backend = MagicMock()
         mock_queue_backend.enqueue = AsyncMock(return_value=True)
@@ -19,18 +21,32 @@ class TestBackgroundWorker:
             mock_queue_backend,
         )
 
-        from app.workers.background_worker import enqueue_task
+        from app.workers.background_worker import background_worker
+        from app.workers.task_queue import TaskStatus, TaskType
 
-        async def dummy_func():
-            pass
+        session = SimpleNamespace(
+            filename="session.wav",
+            duration=30,
+            session_type="lecture",
+        )
 
-        task_id = await enqueue_task(
-            dummy_func,
-            task_name="test_task",
+        task_id = await background_worker.enqueue_recording(
+            session,
+            "user-1",
         )
 
         assert task_id is not None
         mock_queue_backend.enqueue.assert_called_once()
+
+        persisted_task = mock_queue_backend.enqueue.call_args[0][0]
+        assert persisted_task.status == TaskStatus.QUEUED
+        assert persisted_task.task_type == TaskType.RECORDING
+        assert persisted_task.user_id == "user-1"
+        assert persisted_task.payload == {
+            "filename": "session.wav",
+            "duration": 30,
+            "session_type": "lecture",
+        }
 
     @pytest.mark.skip(
         reason="Legacy retry path deprecated during queue migration"

--- a/backend/tests/test_queue_migration_integration.py
+++ b/backend/tests/test_queue_migration_integration.py
@@ -23,12 +23,12 @@ class TestQueueMigrationIntegration:
 
         from app.workers.background_worker import enqueue_task
 
-        async def dummy_task():
-            return True
+        from app.workers.task_queue import TaskType
 
         task_id = await enqueue_task(
-            dummy_task,
-            task_name="integration_test_task",
+            TaskType.COMPRESSION,
+            {"note": "integration_test_task"},
+            user_id="user-1",
         )
 
         assert task_id is not None
@@ -94,16 +94,26 @@ class TestQueueMigrationIntegration:
 
         assert result is True
 
-    async def test_legacy_worker_startup_remains_backward_compatible(
+    async def test_start_worker_schedules_consumer_loop_and_returns_none(
         self,
         monkeypatch,
     ):
         """
-        Ensure legacy startup hook remains callable during migration.
+        start_worker() must schedule the consumer loop in the background
+        and return immediately, without blocking the FastAPI startup path.
         """
 
-        from app.workers.background_worker import start_worker
+        mock_queue_backend = MagicMock()
+        mock_queue_backend.dequeue = AsyncMock(return_value=[])
+
+        monkeypatch.setattr(
+            "app.workers.background_worker.task_queue",
+            mock_queue_backend,
+        )
+
+        from app.workers.background_worker import start_worker, stop_worker
 
         result = start_worker()
-
         assert result is None
+        # Clean up the scheduled task so it doesn't keep polling after the test.
+        await stop_worker()

--- a/backend/tests/test_task_queue_consumer.py
+++ b/backend/tests/test_task_queue_consumer.py
@@ -1,0 +1,262 @@
+"""
+Tests for the persistent task queue consumer: dispatch by task_type,
+completion/retry reporting, and the start_worker/stop_worker lifecycle.
+
+Covers issue #228 — enqueue_task() previously stored only a string preview
+of a callable's args and nothing ever called dequeue(), so enqueued tasks
+were never executed.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.workers.task_queue import Task, TaskStatus, TaskType
+
+
+class TestTaskDispatchRegistry:
+    """Every TaskType must resolve to a registered handler."""
+
+    def test_task_handlers_registered_for_every_task_type(self):
+        from app.workers.background_worker import TASK_HANDLERS
+
+        assert set(TASK_HANDLERS.keys()) == set(TaskType)
+
+
+class TestProcessTask:
+    """_process_task() dispatches a claimed task and reports the outcome."""
+
+    async def test_successful_handler_marks_task_completed(self, monkeypatch):
+        mock_queue_backend = MagicMock()
+        mock_queue_backend.update_status = AsyncMock(return_value=True)
+        mock_queue_backend.mark_for_retry = AsyncMock(return_value=True)
+        monkeypatch.setattr(
+            "app.workers.background_worker.task_queue", mock_queue_backend
+        )
+
+        received = {}
+
+        async def fake_handler(payload, user_id):
+            received["payload"] = payload
+            received["user_id"] = user_id
+
+        monkeypatch.setattr(
+            "app.workers.background_worker.TASK_HANDLERS",
+            {TaskType.RECORDING: fake_handler},
+        )
+
+        from app.workers.background_worker import _process_task
+
+        task = Task(
+            task_id="t1",
+            task_type=TaskType.RECORDING,
+            payload={"filename": "a.wav"},
+            user_id="user-9",
+        )
+        await _process_task(task)
+
+        assert received == {"payload": {"filename": "a.wav"}, "user_id": "user-9"}
+        mock_queue_backend.update_status.assert_called_once_with(
+            "t1", TaskStatus.COMPLETED
+        )
+        mock_queue_backend.mark_for_retry.assert_not_called()
+
+    async def test_handler_failure_marks_task_for_retry_with_exponential_backoff(
+        self, monkeypatch
+    ):
+        mock_queue_backend = MagicMock()
+        mock_queue_backend.update_status = AsyncMock(return_value=True)
+        mock_queue_backend.mark_for_retry = AsyncMock(return_value=True)
+        monkeypatch.setattr(
+            "app.workers.background_worker.task_queue", mock_queue_backend
+        )
+
+        async def failing_handler(payload, user_id):
+            raise ValueError("boom")
+
+        monkeypatch.setattr(
+            "app.workers.background_worker.TASK_HANDLERS",
+            {TaskType.RECORDING: failing_handler},
+        )
+
+        from app.workers.background_worker import _process_task
+
+        # retry_count=2 mirrors a task dequeued after two prior failures.
+        task = Task(
+            task_id="t2",
+            task_type=TaskType.RECORDING,
+            payload={},
+            user_id="user-9",
+            retry_count=2,
+        )
+        await _process_task(task)
+
+        mock_queue_backend.update_status.assert_not_called()
+        mock_queue_backend.mark_for_retry.assert_called_once()
+
+        args, kwargs = mock_queue_backend.mark_for_retry.call_args
+        assert args[0] == "t2"
+        assert kwargs["error_message"] == "boom"
+        assert kwargs["retry_delay"] == 30 * (2**2)  # BASE_RETRY_DELAY_SECONDS * 2^2
+
+    async def test_unregistered_task_type_is_marked_for_retry_not_dropped(
+        self, monkeypatch
+    ):
+        mock_queue_backend = MagicMock()
+        mock_queue_backend.mark_for_retry = AsyncMock(return_value=True)
+        monkeypatch.setattr(
+            "app.workers.background_worker.task_queue", mock_queue_backend
+        )
+        monkeypatch.setattr("app.workers.background_worker.TASK_HANDLERS", {})
+
+        from app.workers.background_worker import _process_task
+
+        task = Task(
+            task_id="t3", task_type=TaskType.COMPRESSION, payload={}, user_id="user-9"
+        )
+        await _process_task(task)
+
+        mock_queue_backend.mark_for_retry.assert_called_once()
+        assert mock_queue_backend.mark_for_retry.call_args[0][0] == "t3"
+
+
+class TestConsumerLoop:
+    """_consumer_loop() drains dequeue() batches and backs off when empty."""
+
+    async def test_processes_dequeued_batch_in_order(self, monkeypatch):
+        monkeypatch.setattr("app.workers.background_worker.POLL_INTERVAL_SECONDS", 0)
+
+        batch = [
+            Task(task_id="a", task_type=TaskType.COMPRESSION, payload={}, user_id="u1"),
+            Task(task_id="b", task_type=TaskType.COMPRESSION, payload={}, user_id="u2"),
+        ]
+        calls = {"n": 0}
+
+        async def fake_dequeue(limit=10):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                return batch
+            raise asyncio.CancelledError()  # stop the loop deterministically
+
+        mock_queue_backend = MagicMock()
+        mock_queue_backend.dequeue = fake_dequeue
+        mock_queue_backend.update_status = AsyncMock(return_value=True)
+        monkeypatch.setattr(
+            "app.workers.background_worker.task_queue", mock_queue_backend
+        )
+
+        processed = []
+
+        async def tracking_handler(payload, user_id):
+            processed.append(user_id)
+
+        monkeypatch.setattr(
+            "app.workers.background_worker.TASK_HANDLERS",
+            {TaskType.COMPRESSION: tracking_handler},
+        )
+
+        from app.workers.background_worker import _consumer_loop
+
+        with pytest.raises(asyncio.CancelledError):
+            await _consumer_loop()
+
+        assert processed == ["u1", "u2"]
+
+    async def test_empty_queue_backs_off_and_polls_again(self, monkeypatch):
+        monkeypatch.setattr("app.workers.background_worker.POLL_INTERVAL_SECONDS", 0)
+
+        calls = {"n": 0}
+
+        async def fake_dequeue(limit=10):
+            calls["n"] += 1
+            if calls["n"] >= 2:
+                raise asyncio.CancelledError()
+            return []
+
+        mock_queue_backend = MagicMock()
+        mock_queue_backend.dequeue = fake_dequeue
+        monkeypatch.setattr(
+            "app.workers.background_worker.task_queue", mock_queue_backend
+        )
+
+        from app.workers.background_worker import _consumer_loop
+
+        with pytest.raises(asyncio.CancelledError):
+            await _consumer_loop()
+
+        assert calls["n"] == 2
+
+
+class TestWorkerLifecycle:
+    """start_worker()/stop_worker() schedule and tear down the loop cleanly."""
+
+    async def test_start_worker_returns_none_and_schedules_a_task(self, monkeypatch):
+        mock_queue_backend = MagicMock()
+        mock_queue_backend.dequeue = AsyncMock(return_value=[])
+        monkeypatch.setattr(
+            "app.workers.background_worker.task_queue", mock_queue_backend
+        )
+
+        import app.workers.background_worker as bw
+
+        result = bw.start_worker()
+        assert result is None
+        assert bw._consumer_task is not None
+        assert not bw._consumer_task.done()
+
+        await bw.stop_worker()
+        assert bw._consumer_task is None
+
+    async def test_stop_worker_is_a_safe_noop_when_never_started(self):
+        import app.workers.background_worker as bw
+
+        bw._consumer_task = None  # baseline, independent of test execution order
+
+        await bw.stop_worker()  # must not raise
+
+        assert bw._consumer_task is None
+
+
+class TestRecordingHandler:
+    """_handle_recording_task() must call record_audio then process_audio."""
+
+    async def test_calls_record_audio_then_process_audio_with_payload_fields(
+        self, monkeypatch
+    ):
+        mock_record_audio = MagicMock(return_value="mock_audio_path.wav")
+        mock_process_audio = AsyncMock(return_value=None)
+
+        monkeypatch.setattr("app.services.audio.record_audio", mock_record_audio)
+        monkeypatch.setattr("app.services.pipeline.process_audio", mock_process_audio)
+
+        from app.workers.background_worker import _handle_recording_task
+
+        await _handle_recording_task(
+            {"filename": "lecture.wav", "duration": 45}, "user-5"
+        )
+
+        mock_record_audio.assert_called_once_with(filename="lecture.wav", duration=45)
+        mock_process_audio.assert_called_once_with("mock_audio_path.wav", "user-5")
+
+
+class TestCompressionHandler:
+    """_handle_compression_task() must promote before enforcing limits."""
+
+    async def test_calls_auto_promote_then_enforce_limits(self, monkeypatch):
+        mock_manager = MagicMock()
+        mock_manager.auto_promote_important_memories = AsyncMock(return_value=None)
+        mock_manager.enforce_lifecycle_limits = AsyncMock(return_value=None)
+
+        monkeypatch.setattr(
+            "app.db.memory_lifecycle.memory_lifecycle_manager", mock_manager
+        )
+
+        from app.workers.background_worker import _handle_compression_task
+
+        await _handle_compression_task({}, "user-77")
+
+        mock_manager.auto_promote_important_memories.assert_called_once_with(
+            "user-77"
+        )
+        mock_manager.enforce_lifecycle_limits.assert_called_once_with("user-77")


### PR DESCRIPTION
Closes #228

### Root cause
`enqueue_task()` stored only a string preview of args/kwargs instead of reconstructable data, and nothing in the codebase ever called `task_queue.dequeue()`. Tasks were written to Mongo and reported as successful, but never picked up or run - so recordings never got transcribed and memory-lifecycle compression never ran.

### Fix
- `enqueue_task()` now takes `task_type` + a serializable `payload` dict instead of an unstorable closure, so a task can be reconstructed after a restart.
- Added a `TASK_HANDLERS` dispatch table mapping `RECORDING`/`COMPRESSION` to their handler functions.
- Added `_consumer_loop()`, which polls `dequeue()` and reports outcomes through the existing `update_status`/`mark_for_retry` API - retry (exponential backoff) and dead-letter logic in `task_queue.py` is
  unchanged.
- `start_worker()`/`stop_worker()` are wired into the FastAPI lifespan, starting after Mongo connects and stopping cleanly before it disconnects.
- Removed the dead in-memory `_worker_loop`/`_queue` compatibility layer, it was never reachable.

### Testing
- New `tests/test_task_queue_consumer.py`: dispatch, retry backoff, empty-queue polling, start/stop lifecycle, both handlers.
- Updated `test_background_worker.py` / `test_queue_migration_integration.py` for the new `enqueue_task` signature.
- `33 passed, 2 skipped` locally (skips are pre-existing, unrelated). No regressions in the rest of the suite.