### PR TITLE
Fix #230: Stale token fallback in logout test after refresh failure

### DIFF
--- a/backend/test_production.py
+++ b/backend/test_production.py
@@ -218,10 +218,17 @@ def main():
     if tokens:
         # Test 3: Refresh Token
         new_tokens = test_refresh_token(tokens)
-        results.append(("Refresh Token", new_tokens is not None))
-        
+        results.append(("Refresh Token", bool(new_tokens)))
+
         # Test 4: Logout
-        results.append(("Logout", test_logout(new_tokens or tokens)))
+        # NOTE: Do NOT fall back to the old tokens if refresh failed.
+        # `new_tokens or tokens` would silently reuse stale/potentially
+        # revoked credentials and mask the refresh failure.
+        if new_tokens:
+            results.append(("Logout", test_logout(new_tokens)))
+        else:
+            print("\n⚠️  Skipping Logout test — refresh failed, refusing to fall back to stale tokens")
+            results.append(("Logout", False))
     
     # Test 5: Extraction Pipeline
     results.append(("Extraction Pipeline", test_pipeline_extract()))


### PR DESCRIPTION
Problem

In main(), test_refresh_token()'s return value was used directly with a truthy fallback:

```new_tokens = test_refresh_token(tokens)
results.append(("Logout", test_logout(new_tokens or tokens)))
```

test_refresh_token() returns False on failure. False or tokens silently evaluates to tokens (the old credentials), so test_logout() runs against stale/potentially revoked tokens with no indication anything went wrong. This made:

Logout tests unreliable - passing/failing under the wrong preconditions
Refresh failures invisible in the test summary
Debugging harder, since the failure had already been masked by the time logout ran
Fix

Closes #230 

Replaced the implicit fallback with an explicit check:
```new_tokens = test_refresh_token(tokens)
results.append(("Refresh Token", bool(new_tokens)))

if new_tokens:
    results.append(("Logout", test_logout(new_tokens)))
else:
    print("\n⚠️  Skipping Logout test — refresh failed, refusing to fall back to stale tokens")
    results.append(("Logout", False))```

Now:

Logout only runs if refresh actually succeeded, so it always tests real (fresh) credentials
If refresh fails, logout is explicitly skipped and marked False in the summary - no silent pass, no silent substitution
The refresh test result itself is now derived from bool(new_tokens) rather than an implicit truthy check downstream
Scope

Change is isolated to main(). No changes to test_refresh_token(), test_logout(), or any other test function.

Testing

Ran the suite locally against both a healthy refresh endpoint and a forced-failure case (invalid refresh token) to confirm logout is skipped and flagged correctly in the latter.


