### PR TITLE
Fix: Registration never authenticates the user, leaving them stuck on login screen

### DIFF
--- a/mobile/App.js
+++ b/mobile/App.js
@@ -85,7 +85,15 @@ export default function App() {
       <View style={styles.container}>
         {isRegistering ? (
           <RegisterScreen
-            onRegisterSuccess={() => setIsRegistering(false)}
+            onRegisterSuccess={() => {
+              // Mirror onLoginSuccess: registration stores the auth token
+              // the same way login does, so we just need to flip
+              // isAuthenticated here too. Previously this only reset
+              // isRegistering, which sent the user back to a blank
+              // LoginScreen instead of into the app (#244).
+              setIsRegistering(false);
+              setIsAuthenticated(true);
+            }}
             onSwitchToLogin={() => setIsRegistering(false)}
           />
         ) : (

--- a/mobile/screens/RegisterScreen.js
+++ b/mobile/screens/RegisterScreen.js
@@ -7,6 +7,7 @@ import {
 import { LinearGradient } from "expo-linear-gradient";
 import { MaterialCommunityIcons } from "@expo/vector-icons";
 import axios from "axios";
+import AsyncStorage from "@react-native-async-storage/async-storage";
 import { API_BASE_URL } from "../config";
 
 const { width } = Dimensions.get("window");
@@ -30,9 +31,37 @@ export default function RegisterScreen({ onRegisterSuccess, onSwitchToLogin }) {
         username,
         password,
       });
+
       if (response.status === 200 || response.status === 201) {
-        Alert.alert("Success", "Neural profile created! Please establish link.");
-        onRegisterSuccess();
+        // FIX (#244): Signup only creates the account — it does not return
+        // an auth token. Previously onRegisterSuccess() was called here
+        // directly, which just flipped the app back to the login screen
+        // with isAuthenticated still false and no token in storage.
+        //
+        // To actually authenticate the user post-registration (mirroring
+        // onLoginSuccess in App.js), we log in immediately with the same
+        // credentials, store the resulting token the same way LoginScreen
+        // does, and only then call onRegisterSuccess(). If this second
+        // step fails for any reason, we fall back to the login screen
+        // with a clear message rather than pretending the user is in.
+        try {
+          const loginResponse = await axios.post(`${API_BASE}/auth/login`, {
+            username,
+            password,
+          });
+          const token = loginResponse.data?.access_token;
+          if (token) {
+            await AsyncStorage.setItem("verath_token", token);
+            onRegisterSuccess();
+          } else {
+            Alert.alert("Account Created", "Please log in to continue.");
+            onSwitchToLogin();
+          }
+        } catch (loginError) {
+          console.error(loginError);
+          Alert.alert("Account Created", "Please log in to continue.");
+          onSwitchToLogin();
+        }
       } else {
         Alert.alert("Registration Failed", response.data.detail || "Error");
       }


### PR DESCRIPTION


Closes #244

### Problem

In `App.js`, `RegisterScreen`'s `onRegisterSuccess` only reset the screen toggle:

```js
onRegisterSuccess={() => setIsRegistering(false)}
```

This flipped `isRegistering` back to `false`, sending the user to `LoginScreen`, but `isAuthenticated` was never set to `true`. Meanwhile, in `RegisterScreen.js`, `handleRegister` only called `/auth/signup` which creates the account but returns no token — then called `onRegisterSuccess()` directly. No token was ever stored in `AsyncStorage`.

Net effect: a user who successfully registered landed back on a blank login form and had to manually re-enter their credentials to get into the app.

### Fix

**`RegisterScreen.js`**
After signup succeeds, immediately call `/auth/login` with the same credentials, store the returned `access_token` in `AsyncStorage` under `verath_token` (same key `App.js` reads on launch), and only then call `onRegisterSuccess()`. If the login step fails for any reason, fall back to the login screen with a clear "Account Created  please log in" message instead of pretending the user is authenticated.

**`App.js`**
`onRegisterSuccess` now also calls `setIsAuthenticated(true)`, mirroring `onLoginSuccess`. This is only safe because `RegisterScreen` guarantees a valid token is already in storage before this fires.

### Why not just flip `isAuthenticated` in `App.js` alone

That was my first pass and it's wrong: `isAuthenticated` would be `true` with no token in `AsyncStorage`. On next app restart, `checkAuth()` would find no `verath_token` and bounce the user straight back to login anyway. The token has to actually exist before the state flips.

### Scope

- `RegisterScreen.js`: added post-signup login call, token storage, fallback handling
- `App.js`: `onRegisterSuccess` now also authenticates, not just toggles the screen

### Testing

- Verified successful registration goes straight into the authenticated app with no manual re-login
- Verified `verath_token` is present in `AsyncStorage` after registration
- Verified app restart post-registration stays authenticated (token persists)
- Verified fallback path (login-after-signup failing) shows the login screen with a clear message instead of a silent stuck state