### PR TITLE
fix(auth): handle DuplicateKeyError during concurrent registration

### DIFF
--- a/backend/app/services/auth.py
+++ b/backend/app/services/auth.py
@@ -1,6 +1,6 @@
 import logging
 import uuid
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Dict, Optional
 
 import bcrypt
@@ -10,6 +10,8 @@ from jose import JWTError, jwt
 
 from app.config import settings
 from app.services.database import get_db
+
+from pymongo.errors import DuplicateKeyError
 
 
 logger = logging.getLogger(__name__)
@@ -133,15 +135,16 @@ def decode_access_token(token: str) -> Optional[Dict]:
 async def create_user(username: str, password: str) -> bool:
     username = username.lower().strip()
     db = get_db()
-    existing = await db["users"].find_one({"username": username})
-    if existing:
+
+    try:
+        await db["users"].insert_one({
+            "username": username,
+            "password_hash": hash_password(password),
+            "created_at": datetime.now(timezone.utc),
+        })
+        return True
+    except DuplicateKeyError:
         return False
-    await db["users"].insert_one({
-        "username": username,
-        "password_hash": hash_password(password),
-        "created_at": datetime.utcnow(),
-    })
-    return True
 
 
 async def authenticate_user(username: str, password: str) -> Optional[str]:

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -469,6 +469,8 @@ class TestAuthServices:
     """Test Authentication Services"""
 
     async def test_create_user_returns_false_on_duplicate_key(self, monkeypatch):
+        
+        """Test that create_user returns False when MongoDB raises DuplicateKeyError."""
 
         # Simulate MongoDB rejecting a duplicate username
 
@@ -481,7 +483,7 @@ class TestAuthServices:
         mock_db.__getitem__.return_value = mock_col
 
         # Replace the real database with the mocked collection
-        
+
         monkeypatch.setattr("app.services.auth.get_db", lambda: mock_db)
 
         result = await create_user("existinguser", "password123")

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -2,6 +2,7 @@ import pytest
 from httpx import AsyncClient
 from unittest.mock import patch, AsyncMock, MagicMock
 from fastapi import status
+from pymongo.errors import DuplicateKeyError
 from app.services.auth import (
     create_access_token,
     create_refresh_token,
@@ -463,3 +464,27 @@ class TestAuth:
         result = await verify_access_token(token)
 
         assert result == "testuser"
+
+class TestAuthServices:
+    """Test Authentication Services"""
+
+    async def test_create_user_returns_false_on_duplicate_key(self, monkeypatch):
+
+        # Simulate MongoDB rejecting a duplicate username
+
+        mock_error = DuplicateKeyError("duplicate username", code=11000)
+
+        mock_col = MagicMock()
+        mock_col.insert_one = AsyncMock(side_effect=mock_error)
+
+        mock_db = MagicMock()
+        mock_db.__getitem__.return_value = mock_col
+
+        # Replace the real database with the mocked collection
+        
+        monkeypatch.setattr("app.services.auth.get_db", lambda: mock_db)
+
+        result = await create_user("existinguser", "password123")
+
+        assert result is False
+        mock_col.insert_one.assert_awaited_once()


### PR DESCRIPTION
## PR Summary

- Increased robustness of user registration workflow by gracefully handling `DuplicateKeyError` raised during concurrent registration attempts.
- The registration service now relies on MongoDB's unique index as source of truth for enforcing username uniqueness.
- A service-level test is added to verify that duplicate key errors are handled correctly.

## Implementation Details

- Updated `create_user()` to catch `DuplicateKeyError` raised by `insert_one()` and return False instead of allowing the exception to propagate.
- Removed the redundant pre-insert `find_one()` existence check, relying on the database's unique index to enforce username uniqueness.
- Added a service-level unit test that mocks `insert_one()` to raise `DuplicateKeyError` and verifies that `create_user()` returns False without exposing the database exception.

## Type of Change

  - [ ] Bug fix (non-breaking change that fixes an issue)
  - [ ] New feature (non-breaking change that adds functionality)
  - [ ] Documentation update (README, guides, comments)
  - [ ] Style / UI change (no logic change)
  - [ ] Code refactor (no behavior change)
  - [ ] Test addition or update
  - [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

 - [x] I have tested my changes locally
 - [x] My code follows the existing code style (TypeScript, Tailwind, no any types)
 - [x] I have not introduced unrelated changes (each PR should address one issue)
 - [x] I have added comments where necessary
 - [x] My branch is up to date with main
 - [x] I have linked the related issue

## Additional Details

- Labels: GSSoC'2026, type: performance, type: enhancement
- Closes #263 