### PR TITLE
Fix: intent misclassification from pattern overlap

### DIFF
--- a/backend/app/pipeline/extraction_pipeline.py
+++ b/backend/app/pipeline/extraction_pipeline.py
@@ -21,27 +21,28 @@ class ExtractionPipeline:
         r'\bsorry\b'
     ]
     
-    # Intent detection patterns
+    # Intent detection patterns (order matters: first match wins, so more
+    # specific intents are listed before broader ones they overlap with)
     INTENT_PATTERNS = {
+        'reminder': [
+            r'\bremind\b', r'\bdon\'t forget\b', r'\bremember\b',
+            r'\bnote\b', r'\bmake sure\b'
+        ],
+        'task': [
+            r'\btask\b', r'\bto do\b', r'\bneed to\b', r'\bhave to\b',
+            r'\bgotta\b', r'\bshould\b'
+        ],
         'meeting': [
             r'\bmeet\b', r'\bmeeting\b', r'\bcall\b', r'\bconference\b', 
             r'\bdiscuss\b', r'\bappointment\b', r'\bget together\b'
         ],
         'deadline': [
             r'\bdeadline\b', r'\bdue\b', r'\bsubmit\b', r'\bcomplete by\b',
-            r'\bfinish by\b', r'\bneed to\b'
-        ],
-        'task': [
-            r'\btask\b', r'\bto do\b', r'\bneed to\b', r'\bhave to\b',
-            r'\bgotta\b', r'\bshould\b'
+            r'\bfinish by\b'
         ],
         'commitment': [
             r'\bpromise\b', r'\bcommit\b', r'\bagree\b', r'\bwill\b',
             r'\bsure\b', r'\babsolutely\b'
-        ],
-        'reminder': [
-            r'\bremind\b', r'\bdon\'t forget\b', r'\bremember\b',
-            r'\bnote\b', r'\bmake sure\b'
         ]
     }
     


### PR DESCRIPTION
## Summary
`_detect_intent` returns the first matching intent in `INTENT_PATTERNS` dict order. `meeting` (includes `\bcall\b`) was
checked before `reminder`, so "remind me to call Sarah" matched `meeting` instead. Separately, `\bneed to\b` was listed under both `deadline` and `task`, with `deadline` checked first, so `task` could never win that phrase.

Moved `reminder`/`task` (more specific markers) ahead of `meeting`/`deadline`, and removed the duplicate `need to` from
`deadline`.

Note: this changes classification for text mixing a task marker with a meeting/deadline word - e.g. "we need to meet" now resolves to `task`, not `meeting`. That's the intended effect of checking the more specific pattern first, not a side effect.

Part of #248.

## Test plan
- [x] `pytest tests/test_real_world.py::test_intent_classification -v` - 5/5 pass (was 3/5)
- [x] `pytest tests/test_real_world.py -v` - nothing else regresses