### PR TITLE
Fix: temporal parsing for 'next <weekday>' phrases

### DIFF
--- a/backend/app/pipeline/extraction_pipeline.py
+++ b/backend/app/pipeline/extraction_pipeline.py
@@ -183,6 +183,9 @@ class ExtractionPipeline:
                     'RELATIVE_BASE': datetime.utcnow(),
                     'PREFER_DATES_FROM': 'future'
                 })
+
+                if not parsed:
+                    parsed = self._resolve_next_weekday(phrase)
                 
                 if parsed:
                     temporal_entities["dates"].append({
@@ -192,6 +195,17 @@ class ExtractionPipeline:
                     })
         
         return temporal_entities
+
+    def _resolve_next_weekday(self, phrase: str) -> Optional[datetime]:
+        """Compute 'next <weekday>' directly; dateparser returns None for this phrasing."""
+        weekdays = ['monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday']
+        weekday_name = phrase.lower().replace('next', '').strip()
+        if weekday_name not in weekdays:
+            return None
+
+        today = datetime.utcnow()
+        days_ahead = (weekdays.index(weekday_name) - today.weekday()) % 7 or 7
+        return today + timedelta(days=days_ahead)
     
     def _detect_intent(self, text: str) -> Optional[str]:
         """Rule-based intent detection."""


### PR DESCRIPTION
## Summary
`time_patterns` includes `\bnext \w+day\b` to catch phrases like "next Monday". The regex matches fine, but `dateparser.parse()` itself returns `None` for "next <weekday>" phrasing - confirmed "Monday" alone and "next week" both parse, "next <weekday>" doesn't, across all seven days.

Added a fallback that computes the date directly when dateparser returns None for one of these matches, instead of relying on the library for this one phrasing.

Part of #248.

## Test plan
- [x] `pytest "tests/test_real_world.py::test_temporal_parsing[next Monday-True]" -v` - passes
- [x] `pytest tests/test_real_world.py::test_temporal_parsing -v` - full param set, no regressions
- [x] Verified the fallback against all 7 weekdays, not just Monday