### PR TITLE
fix: cache key now includes all function arguments, not just user_id/date (closes #282)

### DIFF
--- a/backend/app/core/cache.py
+++ b/backend/app/core/cache.py
@@ -1,5 +1,6 @@
 import time
 import hashlib
+import inspect
 from functools import wraps
 from typing import Callable, Any, Optional
 from fastapi import Response
@@ -54,78 +55,87 @@ class SimpleCache:
 _cache = SimpleCache()
 
 
-def cached(ttl_seconds: int = 300, key_prefix: str = ""):
+def _default_key_func(func: Callable, args: tuple, kwargs: dict) -> str:
+    """
+    Builds a deterministic key suffix from ALL bound arguments instead of
+    a hand-picked subset (previously only user_id/date were used, which
+    caused different calls — e.g. different post_id — to collide on the
+    same cache key). Uses inspect.signature to bind args/kwargs to
+    parameter names so equivalent calls (positional vs keyword) produce
+    the SAME key, while calls with different values always differ.
+    """
+    try:
+        sig = inspect.signature(func)
+        bound = sig.bind(*args, **kwargs)
+        bound.apply_defaults()
+        arg_items = sorted(bound.arguments.items())
+    except TypeError:
+        # Fallback for signatures that don't bind cleanly (e.g. *args-only)
+        arg_items = [("args", args), ("kwargs", sorted(kwargs.items()))]
+
+    return repr(arg_items)
+
+
+def cached(ttl_seconds: int = 300, key_prefix: str = "", key_func: Optional[Callable] = None):
     """
     Decorator to cache function results with TTL.
     
     Args:
         ttl_seconds: Time to live in seconds (default 5 minutes)
         key_prefix: Prefix for cache key
+        key_func: Optional callable (func, args, kwargs) -> str. Use this
+            to explicitly control which arguments participate in the cache
+            key — e.g. to exclude a non-hashable object like a db session.
+            If omitted, ALL bound arguments are used by default (safe).
     """
     def decorator(func: Callable) -> Callable:
+
+        def _build_key_hash(args, kwargs) -> str:
+            if key_func is not None:
+                key_suffix = key_func(func, args, kwargs)
+            else:
+                key_suffix = _default_key_func(func, args, kwargs)
+
+            key = ":".join([key_prefix, func.__name__, key_suffix])
+            return hashlib.md5(key.encode()).hexdigest()
+
         @wraps(func)
         async def async_wrapper(*args, **kwargs):
-            # Generate cache key from function name and arguments
-            key_parts = [key_prefix, func.__name__]
-            
-            # Add user_id if present in kwargs or args
-            if 'user_id' in kwargs:
-                key_parts.append(str(kwargs['user_id']))
-            elif args and hasattr(args[0], 'user_id'):
-                key_parts.append(str(args[0].user_id))
-            
-            # Add date if present for daily caches
-            if 'date' in kwargs:
-                key_parts.append(str(kwargs['date']))
-            
-            key = ":".join(key_parts)
-            key_hash = hashlib.md5(key.encode()).hexdigest()
-            
+            key_hash = _build_key_hash(args, kwargs)
+
             # Check cache
             cached_value = _cache.get(key_hash)
             if cached_value is not None:
                 return cached_value
-            
+
             # Execute function
             result = await func(*args, **kwargs)
-            
+
             # Store in cache
             _cache.set(key_hash, result, ttl_seconds)
-            
+
             return result
-        
+
         # Also support sync functions
         @wraps(func)
         def sync_wrapper(*args, **kwargs):
-            key_parts = [key_prefix, func.__name__]
-            
-            if 'user_id' in kwargs:
-                key_parts.append(str(kwargs['user_id']))
-            elif args and hasattr(args[0], 'user_id'):
-                key_parts.append(str(args[0].user_id))
-            
-            if 'date' in kwargs:
-                key_parts.append(str(kwargs['date']))
-            
-            key = ":".join(key_parts)
-            key_hash = hashlib.md5(key.encode()).hexdigest()
-            
+            key_hash = _build_key_hash(args, kwargs)
+
             cached_value = _cache.get(key_hash)
             if cached_value is not None:
                 return cached_value
-            
+
             result = func(*args, **kwargs)
             _cache.set(key_hash, result, ttl_seconds)
-            
+
             return result
-        
+
         # Return appropriate wrapper based on whether function is async
-        import inspect
         if inspect.iscoroutinefunction(func):
             return async_wrapper
         else:
             return sync_wrapper
-    
+
     return decorator
 
 


### PR DESCRIPTION
## Description
Fixes a cache key correctness bug where the `cached` decorator only used
`user_id` and `date` when building cache keys, silently ignoring every
other argument (`post_id`, `page`, `filters`, `query`, etc.). This caused
calls with different arguments but the same `user_id` to collide on the
same cache key, resulting in cross-request data leaks — one request could
receive another request's cached result.

Closes #282

## Root cause
```python
key_parts = [key_prefix, func.__name__]
if 'user_id' in kwargs:
    key_parts.append(str(kwargs['user_id']))
elif args and hasattr(args[0], 'user_id'):
    key_parts.append(str(args[0].user_id))
if 'date' in kwargs:
    key_parts.append(str(kwargs['date']))
```
Any argument outside this hand-picked subset was dropped from the key
entirely, present in both `async_wrapper` and `sync_wrapper`.

## Fix
Replaced the hand-picked key construction with `_default_key_func`, which:
- Uses `inspect.signature(func).bind()` to bind all positional and keyword
  arguments to their parameter names, then builds the key from the full
  sorted argument set — not a subset.
- Ensures equivalent calls (e.g. `get_post(1, 42)` vs
  `get_post(post_id=1, user_id=42)`) produce the **same** key (correct —
  should share a cache entry), while calls with genuinely different
  argument values always produce **different** keys (the actual bug).
- Falls back gracefully if signature binding fails for edge-case function
  signatures (e.g. bare `*args`/`**kwargs` functions).

Also added an optional `key_func` parameter to `cached()`, so callers can
explicitly opt into excluding specific arguments (e.g. a non-hashable `db`
session object) from the cache key, rather than having them silently and
implicitly dropped as before.

## Testing
Added regression tests covering:
- Different positional arguments produce different cache entries
  (the exact repro case from the issue)
- Different keyword arguments produce different cache entries
- Identical repeated calls correctly hit the cache (no unnecessary
  re-execution)
- Positional and keyword-equivalent calls share the same cache entry
- Sync function variant behaves identically to async
- `key_func` override correctly excludes a non-hashable argument (e.g.
  a fake db session) while still varying on the arguments that matter

All existing tests in the suite pass unchanged.

## Behavioral note for reviewers
This change alters the cache key format, which means **all existing cache
entries become unreachable on deploy** — not stale/wrong, just orphaned
(they'll be pruned naturally by TTL expiry or overwritten). This is safe:
every "miss" just falls through to a fresh function call, same as a cold
cache. No stale/incorrect data can be served during the transition.

## Checklist
- [x] Bug reproduced and root cause confirmed against original code
- [x] Fix implemented in both `async_wrapper` and `sync_wrapper`
- [x] Regression tests added per @Chetan0e's request in the issue
- [x] `key_func` escape hatch added per suggested fix in the issue