### PR TITLE
fix: never combine wildcard CORS origin with allow_credentials=True

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -74,7 +74,7 @@ class Settings(BaseSettings):
     host: str = "0.0.0.0"
     port: int = 8000
     default_record_seconds: int = 10
-    allow_cors: str = "*"
+    allow_cors: str = "http://localhost:8080,http://localhost:3000"
     env: str = "development"
 
     # ── Storage ───────────────────────────────────────────────────────────────

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -193,9 +193,36 @@ app.add_exception_handler(VerathException, verath_exception_handler)
 app.add_exception_handler(HTTPException, http_exception_handler)
 app.add_exception_handler(RequestValidationError, validation_exception_handler)
 
+def _resolve_cors_origins() -> list[str]:
+    """
+    Resolve the list of allowed CORS origins.
+
+    A wildcard ("*") must never be combined with allow_credentials=True:
+    browsers reject credentialed responses against a literal "*", and
+    Starlette's CORSMiddleware falls back to reflecting whatever Origin
+    header the request sent — which effectively allows any origin to make
+    credentialed requests. So "*" is stripped out here regardless of env,
+    and we fall back to safe localhost-only defaults if nothing is left.
+    """
+    raw_origins = settings.allow_cors.split(",")
+    origins = [o.strip() for o in raw_origins if o.strip()]
+
+    if "*" in origins:
+        logger.warning(
+            "ALLOW_CORS contains '*' while allow_credentials=True is set. "
+            "Dropping '*' — set ALLOW_CORS to a comma-separated list of "
+            "real origins instead."
+        )
+        origins = [o for o in origins if o != "*"]
+
+    if not origins:
+        origins = ["http://localhost:8080", "http://localhost:3000"]
+
+    return origins
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=settings.allow_cors.split(",") if settings.env == "production" else ["*"],
+    allow_origins=_resolve_cors_origins(),
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],


### PR DESCRIPTION
## Summary

Fixes a CORS misconfiguration where `allow_credentials=True` was combined with a wildcard origin (`allow_origins=["*"]`) whenever the app wasn't running with `ENV=production` (the default for local/dev setups).

Per the CORS/Fetch spec, browsers reject credentialed responses against a literal `"*"`. To work around this, Starlette's `CORSMiddleware` falls back to reflecting whatever `Origin` header the incoming request sent, which effectively allows **any** origin to make credentialed requests (cookies, or JS-held Authorization headers) to the API, silently defeating CORS protection.

## Changes

- **`backend/app/main.py`**: Replaced the inline `allow_origins=... if settings.env == "production" else ["*"]` logic with a `_resolve_cors_origins()` helper that:
  - Strips `"*"` out of the resolved origin list regardless of environment
  - Logs a warning if `"*"` was found and removed
  - Falls back to explicit localhost origins if the resolved list ends up empty
- **`backend/app/config.py`**: Updated the `allow_cors` field's fallback default to an explicit localhost origin list instead of a bare `"*"`, so the insecure wildcard is never the default even before `.env` is loaded.

## Why this matters

- In dev mode (the default), any external site could previously issue credentialed cross-origin requests against a locally running backend.
- The fix removes the wildcard-with-credentials combination unconditionally, rather than only fixing it for production, so local development is no longer silently exposed either.

## Testing

- Reviewed the diff manually to confirm `_resolve_cors_origins()` is defined above the `app.add_middleware(CORSMiddleware, ...)` call and correctly wired in.
- Did not run the full app locally due to unrelated startup dependencies, this PR does not touch any of those code paths.

Closes #299