### PR TITLE
fix: renew task heartbeat during handler execution

### DIFF
--- a/backend/app/workers/background_worker.py
+++ b/backend/app/workers/background_worker.py
@@ -33,6 +33,7 @@ logger = logging.getLogger(__name__)
 
 POLL_INTERVAL_SECONDS = 5
 BASE_RETRY_DELAY_SECONDS = 30
+HEARTBEAT_INTERVAL_SECONDS = 60  # must stay well under TaskQueue.HEARTBEAT_TIMEOUT (5 min)
 
 _consumer_task: Optional[asyncio.Task] = None
 
@@ -117,6 +118,18 @@ TASK_HANDLERS: Dict[TaskType, Callable[[Dict[str, Any], str], Any]] = {
 
 
 # ── Consumer loop ─────────────────────────────────────────────────────────────
+async def _heartbeat_loop(task_id: str) -> None:
+    """Renew a claimed task's heartbeat every HEARTBEAT_INTERVAL_SECONDS.
+
+    Runs alongside a handler for as long as _process_task lets it; without
+    this, a handler running past TaskQueue.HEARTBEAT_TIMEOUT looks stale and
+    dequeue() reclaims it for another worker while it's still in progress.
+    """
+    while True:
+        await asyncio.sleep(HEARTBEAT_INTERVAL_SECONDS)
+        await task_queue.update_heartbeat(task_id)
+
+
 async def _process_task(task: Task) -> None:
     """Run a single claimed task and report the outcome back to task_queue."""
 
@@ -133,6 +146,7 @@ async def _process_task(task: Task) -> None:
         )
         return
 
+    heartbeat_task = asyncio.create_task(_heartbeat_loop(task.task_id))
     try:
         await handler(task.payload, task.user_id)
         await task_queue.update_status(task.task_id, TaskStatus.COMPLETED)
@@ -150,6 +164,13 @@ async def _process_task(task: Task) -> None:
             stack_trace=traceback.format_exc(),
             retry_delay=retry_delay,
         )
+
+    finally:
+        heartbeat_task.cancel()
+        try:
+            await heartbeat_task
+        except asyncio.CancelledError:
+            pass
 
 
 async def _consumer_loop() -> None:

--- a/backend/tests/test_task_queue_consumer.py
+++ b/backend/tests/test_task_queue_consumer.py
@@ -260,3 +260,80 @@ class TestCompressionHandler:
             "user-77"
         )
         mock_manager.enforce_lifecycle_limits.assert_called_once_with("user-77")
+
+
+class TestHeartbeatRenewal:
+    """_process_task() must keep a claimed task's heartbeat alive while its handler runs."""
+
+    async def test_heartbeat_is_renewed_while_handler_runs(self, monkeypatch):
+        monkeypatch.setattr(
+            "app.workers.background_worker.HEARTBEAT_INTERVAL_SECONDS", 0.01
+        )
+
+        mock_queue_backend = MagicMock()
+        mock_queue_backend.update_status = AsyncMock(return_value=True)
+        mock_queue_backend.update_heartbeat = AsyncMock(return_value=True)
+        monkeypatch.setattr(
+            "app.workers.background_worker.task_queue", mock_queue_backend
+        )
+
+        async def slow_handler(payload, user_id):
+            await asyncio.sleep(0.05)
+
+        monkeypatch.setattr(
+            "app.workers.background_worker.TASK_HANDLERS",
+            {TaskType.RECORDING: slow_handler},
+        )
+
+        from app.workers.background_worker import _process_task
+
+        task = Task(
+            task_id="hb-1", task_type=TaskType.RECORDING, payload={}, user_id="user-1"
+        )
+        await _process_task(task)
+
+        assert mock_queue_backend.update_heartbeat.call_count >= 2
+        mock_queue_backend.update_heartbeat.assert_called_with("hb-1")
+
+    async def test_heartbeat_loop_is_cancelled_even_when_handler_fails(
+        self, monkeypatch
+    ):
+        monkeypatch.setattr(
+            "app.workers.background_worker.HEARTBEAT_INTERVAL_SECONDS", 0.01
+        )
+
+        mock_queue_backend = MagicMock()
+        mock_queue_backend.mark_for_retry = AsyncMock(return_value=True)
+        mock_queue_backend.update_heartbeat = AsyncMock(return_value=True)
+        monkeypatch.setattr(
+            "app.workers.background_worker.task_queue", mock_queue_backend
+        )
+
+        async def failing_handler(payload, user_id):
+            await asyncio.sleep(0.02)
+            raise ValueError("boom")
+
+        monkeypatch.setattr(
+            "app.workers.background_worker.TASK_HANDLERS",
+            {TaskType.RECORDING: failing_handler},
+        )
+
+        created = []
+        real_create_task = asyncio.create_task
+
+        def tracking_create_task(coro, *a, **kw):
+            t = real_create_task(coro, *a, **kw)
+            created.append(t)
+            return t
+
+        monkeypatch.setattr("asyncio.create_task", tracking_create_task)
+
+        from app.workers.background_worker import _process_task
+
+        task = Task(
+            task_id="hb-2", task_type=TaskType.RECORDING, payload={}, user_id="user-1"
+        )
+        await _process_task(task)  # must not raise or hang
+
+        mock_queue_backend.mark_for_retry.assert_called_once()
+        assert created[0].done() and created[0].cancelled()


### PR DESCRIPTION
**Fixes #296**

#### Problem
`dequeue()` resets any task stuck in `PROCESSING` whose `heartbeat_at` is older than `HEARTBEAT_TIMEOUT` (5 minutes) back to `QUEUED`, so another worker can pick it up meant to recover tasks orphaned by a crashed worker. `update_heartbeat()` exists to keep this from firing on a task that's still legitimately running, but it was never called anywhere. The consumer loop just awaits the handler straight through, and handlers aren't even passed `task_id`, so they couldn't renew it themselves either.

Recordings are allowed up to 3600 seconds and compression loops over every one of a user's memories either can easily exceed 5 minutes in normal operation, not just on error. With more than one worker process, a task still genuinely running gets reclaimed and re-run by a second worker while the original is still going duplicate recordings, duplicate LLM calls, a compression job running twice. The losing worker's completion write silently no-ops, so this leaves no trace.

#### Fix
Run a heartbeat-renewal loop alongside the handler, cancelled once it finishes - same cancel/await/suppress pattern this file already uses in `stop_worker()`.

#### Changes
- `backend/app/workers/background_worker.py` added `HEARTBEAT_INTERVAL_SECONDS`, `_heartbeat_loop()`, wired into `_process_task()`.
- `backend/tests/test_task_queue_consumer.py` added `TestHeartbeatRenewal`: renewal during a running handler, cleanup on success and on failure.

#### Testing
- Reproduced against the original code: `update_heartbeat` called 0 times during a slow handler.
- Verified the fix: renewed periodically, cancelled cleanly on both success and failure.
- Full regression pass across every file touching these modules all green except one pre-existing, unrelated failure (confirmed to fail identically on the original code).
```
pytest tests/test_task_queue_consumer.py tests/test_background_worker.py tests/test_dead_letter_retry.py tests/test_queue_migration_integration.py tests/test_task_queue_init_race.py -v
```