### PR TITLE
fix: enforce_lifecycle_limits reads importance from metadata.importance

### DIFF
--- a/backend/app/db/memory_lifecycle.py
+++ b/backend/app/db/memory_lifecycle.py
@@ -113,7 +113,7 @@ class MemoryLifecycleManager:
                 }).sort("timestamp", 1).limit(excess)
                 
                 async for mem in cursor:
-                    if mem.get("importance", 0) >= self.IMPORTANCE_THRESHOLD:
+                    if mem.get("metadata", {}).get("importance", 0) >= self.IMPORTANCE_THRESHOLD:
                         await self.promote_to_long_term(user_id, mem["_id"])
                     else:
                         await self.archive_memory(user_id, mem["_id"])

--- a/backend/tests/test_lifecycle_field_divergence.py
+++ b/backend/tests/test_lifecycle_field_divergence.py
@@ -9,6 +9,8 @@ Verifies that:
 5. auto_promote_important_memories increments promoted_count and does not archive
    memories that passed the importance gate.
 6. Full short_term → long_term → archived lifecycle transition succeeds end-to-end.
+7. enforce_lifecycle_limits reads metadata.importance (not top-level importance)
+   when deciding promote vs archive on short-term overflow.
 """
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch, call
@@ -330,3 +332,42 @@ class TestFullLifecycleTransition:
         assert stats["short_term"] == 5
         assert stats["long_term"] == 2
         assert stats["archived"] == 1
+
+
+# ── 7. enforce_lifecycle_limits uses metadata.importance ─────────────────────
+
+class TestEnforceLifecycleLimitsUsesMetadataImportance:
+    async def test_high_importance_doc_is_promoted_not_archived(self, monkeypatch):
+        """A short-term memory over the importance threshold must be promoted
+        when the short-term cap is exceeded, not archived like the rest."""
+        doc = {"_id": "mem-hi", "metadata": {"importance": 0.9}}
+
+        mock_col = _make_collection([doc], modified_count=1, count_return=101)
+        mock_db = MagicMock()
+        mock_db.memories = mock_col
+
+        monkeypatch.setattr("app.db.memory_lifecycle.get_db", lambda: mock_db)
+
+        from app.db.memory_lifecycle import MemoryLifecycleManager
+        await MemoryLifecycleManager().enforce_lifecycle_limits("u1")
+
+        for c in mock_col.update_one.call_args_list:
+           update = c[0][1]
+           assert update["$set"].get("lifecycle_stage") != "archived", \
+               "high-importance doc must be promoted, not archived, on short-term overflow"
+    async def test_low_importance_doc_is_still_archived(self, monkeypatch):
+        """A short-term memory under the threshold must still be archived —
+        the fix must not flip to promoting everything either."""
+        doc = {"_id": "mem-lo", "metadata": {"importance": 0.1}}
+
+        mock_col = _make_collection([doc], modified_count=1, count_return=101)
+        mock_db = MagicMock()        
+        mock_db.memories = mock_col
+
+        monkeypatch.setattr("app.db.memory_lifecycle.get_db", lambda: mock_db)
+
+        from app.db.memory_lifecycle import MemoryLifecycleManager
+        await MemoryLifecycleManager().enforce_lifecycle_limits("u1")
+
+        update = mock_col.update_one.call_args[0][1]
+        assert update["$set"].get("lifecycle_stage") == "archived"


### PR DESCRIPTION
**Fixes #297**

#### Problem
Memory documents store importance nested at `metadata.importance` confirmed in `store_memory()`, where the whole input `metadata` dict is stored verbatim under `doc["metadata"]`. There's no top-level `importance` key in the schema.

`auto_promote_important_memories()` reads this correctly. Its sibling `enforce_lifecycle_limits()` called right after it, on the same compression task reads `mem.get("importance", 0)`, which always falls back to `0`. So every excess short-term memory gets archived once a user crosses `MAX_SHORT_TERM` (100), regardless of true importance a memory scored 0.95 is archived exactly like one scored 0.05.

Same field-divergence bug `test_lifecycle_field_divergence.py` already tests and fixes in four other methods — this one wasn't among them, and its own existing test only checked that *an* update happened, not which branch fired, so it never caught this.

#### Fix
Read `metadata.importance` instead of the nonexistent top-level field - a one-line change.

#### Changes
- `backend/app/db/memory_lifecycle.py` - `enforce_lifecycle_limits()` now reads `mem.get("metadata", {}).get("importance", 0)`.
- `backend/tests/test_lifecycle_field_divergence.py` - added `TestEnforceLifecycleLimitsUsesMetadataImportance`, matching the existing pattern used for `auto_promote_important_memories`.

#### Testing
- Confirmed the new test fails against the original code (`'archived' != 'archived'` - a 0.9-importance memory got archived).
- Verified the fix: both new tests pass.
- Full regression pass on `test_lifecycle_field_divergence.py` (11/11 relevant) and `test_lifecycle_schema.py` — no existing test broken.
```
pytest tests/test_lifecycle_field_divergence.py tests/test_lifecycle_schema.py -v
```